### PR TITLE
fix/dependency-cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,7 @@
                 "prettier": "^3.5.3",
                 "rimraf": "^5.0.1",
                 "serverless-http": "^3.2.0",
-                "sinon": "^15.2.0",
-                "supertest": "^6.3.3"
+                "sinon": "^15.2.0"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -4086,13 +4085,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/asap": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4102,13 +4094,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
@@ -4850,19 +4835,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/commander": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
@@ -4871,16 +4843,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=16"
-            }
-        },
-        "node_modules/component-emitter": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-            "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/concat-map": {
@@ -4975,13 +4937,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-            "license": "MIT"
-        },
-        "node_modules/cookiejar": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
-            "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/create-jest": {
@@ -5197,16 +5152,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5234,17 +5179,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/dezalgo": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
-            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
             }
         },
         "node_modules/diff": {
@@ -6078,13 +6012,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/fast-xml-parser": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
@@ -6286,38 +6213,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/formidable": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-            "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dezalgo": "^1.0.4",
-                "hexoid": "^1.0.0",
-                "once": "^1.4.0",
-                "qs": "^6.11.0"
-            },
-            "funding": {
-                "url": "https://ko-fi.com/tunnckoCore/commissions"
             }
         },
         "node_modules/forwarded": {
@@ -6712,16 +6607,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=16.0.0"
-            }
-        },
-        "node_modules/hexoid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-            "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/html-escaper": {
@@ -9032,9 +8917,9 @@
             }
         },
         "node_modules/on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10641,56 +10526,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/superagent": {
-            "version": "8.1.2",
-            "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-            "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
-            "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "component-emitter": "^1.3.0",
-                "cookiejar": "^2.1.4",
-                "debug": "^4.3.4",
-                "fast-safe-stringify": "^2.1.1",
-                "form-data": "^4.0.0",
-                "formidable": "^2.1.2",
-                "methods": "^1.1.2",
-                "mime": "2.6.0",
-                "qs": "^6.11.0",
-                "semver": "^7.3.8"
-            },
-            "engines": {
-                "node": ">=6.4.0 <13 || >=14"
-            }
-        },
-        "node_modules/superagent/node_modules/mime": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/supertest": {
-            "version": "6.3.4",
-            "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
-            "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "methods": "^1.1.2",
-                "superagent": "^8.1.2"
-            },
-            "engines": {
-                "node": ">=6.4.0"
-            }
         },
         "node_modules/supports-color": {
             "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
         "prettier": "^3.5.3",
         "rimraf": "^5.0.1",
         "serverless-http": "^3.2.0",
-        "sinon": "^15.2.0",
-        "supertest": "^6.3.3"
+        "sinon": "^15.2.0"
     },
     "jest": {
         "testEnvironment": "node",
@@ -114,6 +113,9 @@
         "*.md": [
             "prettier --write"
         ]
+    },
+    "overrides": {
+        "on-headers": "^1.1.0"
     },
     "engines": {
         "node": ">=18.0.0"


### PR DESCRIPTION
1. Removed the unused supertest and its dependencies which included form-data which presented a vulnerability.
2.  Overrided the version of on-headers to be 1.1.0 to remove a vulnerability.