### PR TITLE
feat/sanctum

### DIFF
--- a/scripts/init-tables.js
+++ b/scripts/init-tables.js
@@ -299,6 +299,110 @@ async function main() {
     }
   }
 
+  // ============================================
+  // Seed Dev Test User (matches cognito-client.js test credentials)
+  // ============================================
+
+  const TEST_USER_ID = 'usr_a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+  const TEST_USER_EMAIL = 'testplayer1@example.com';
+  const TEST_USER_NAME = 'TestPlayer1';
+  const now = new Date().toISOString();
+  const today = now.slice(0, 10);
+
+  // Check if test user already exists
+  let userExists = false;
+  try {
+    const result = await dynamoRequest('GetItem', {
+      TableName: 'TotemBound-Users',
+      Key: { pk: { S: `USER#${TEST_USER_ID}` }, sk: { S: 'PROFILE' } },
+    });
+    userExists = !!result.Item;
+  } catch (e) { /* table may be empty */ }
+
+  if (userExists) {
+    console.log(`✓ Dev test user already seeded (${TEST_USER_EMAIL})`);
+  } else {
+    console.log('');
+    console.log('🌱 Seeding dev test user...');
+
+    const lootId = `lot_seed-uncommon-box-001`;
+    const txnId = `txn_seed-signup-bonus-001`;
+
+    // 1. User profile record (2000 Essence, 0 Gems — same as runtime signup)
+    await dynamoRequest('PutItem', {
+      TableName: 'TotemBound-Users',
+      Item: {
+        pk: { S: `USER#${TEST_USER_ID}` },
+        sk: { S: 'PROFILE' },
+        id: { S: TEST_USER_ID },
+        email: { S: TEST_USER_EMAIL },
+        displayName: { S: TEST_USER_NAME },
+        tier: { S: 'free' },
+        currencies: { M: {
+          essence: { N: '2000' },
+          gems: { N: '0' },
+        }},
+        stats: { M: {
+          totalTotems: { N: '0' },
+          totalChallengesCompleted: { N: '0' },
+          loginStreak: { N: '0' },
+          lastLoginDate: { S: today },
+        }},
+        settings: { M: {
+          notifications: { BOOL: true },
+          darkMode: { S: 'dark' },
+        }},
+        createdAt: { S: now },
+        updatedAt: { S: now },
+      },
+    });
+    console.log(`  ✓ User profile (${TEST_USER_EMAIL}, 2000 Essence)`);
+
+    // 2. Uncommon Totem Box loot item (unclaimed — matches runtime grantLootItem() exactly)
+    await dynamoRequest('PutItem', {
+      TableName: 'TotemBound-RewardState',
+      Item: {
+        pk: { S: `USER#${TEST_USER_ID}` },
+        sk: { S: `LOOT#${lootId}` },
+        id: { S: lootId },
+        userId: { S: TEST_USER_ID },
+        boxId: { S: 'uncommon_totem_box' },
+        source: { S: 'signup' },
+        status: { S: 'unclaimed' },
+        grantedAt: { S: now },
+        claimedAt: { NULL: true },
+        claimResult: { NULL: true },
+      },
+    });
+    console.log('  ✓ Uncommon Totem Box (unclaimed loot)');
+
+    // 3. Signup bonus transaction log (matches runtime logTransaction() exactly)
+    const shortId = 'seed01';
+    await dynamoRequest('PutItem', {
+      TableName: 'TotemBound-Transactions',
+      Item: {
+        pk: { S: `TXN#${now}#${shortId}` },
+        sk: { S: `USER#${TEST_USER_ID}` },
+        id: { S: txnId },
+        userId: { S: TEST_USER_ID },
+        type: { S: 'reward_signup' },
+        currency: { S: 'essence' },
+        amount: { N: '2000' },
+        balanceBefore: { N: '0' },
+        balanceAfter: { N: '2000' },
+        ts: { S: now },
+        refType: { S: 'reward' },
+        refName: { S: 'Welcome Bonus' },
+      },
+    });
+    console.log('  ✓ Signup bonus transaction (2000 Essence)');
+
+    // 4. No achievements on signup — they fire when loot box is claimed (onTotemAcquired)
+    console.log('  ℹ  No achievements seeded (fire on first totem claim, not signup)');
+
+    console.log(`  ✅ Dev test user ready! Login: ${TEST_USER_EMAIL} / TestPassword123!`);
+  }
+
   console.log('');
   console.log('✅ Tables initialized!');
   console.log('');

--- a/src/app.js
+++ b/src/app.js
@@ -169,7 +169,7 @@ app.get('/v1/auth/me', authenticateJWT, handleGetMe);
 
 // Import route handlers
 let userRoutes, totemRoutes, gameActionRoutes, challengeRoutes,
-  expeditionRoutes, rewardRoutes, achievementRoutes, shopRoutes;
+  expeditionRoutes, rewardRoutes, achievementRoutes, shopRoutes, sanctumRoutes;
 
 const loadRoutes = () => {
   const tryRequire = (path, name) => {
@@ -190,6 +190,7 @@ const loadRoutes = () => {
   rewardRoutes = tryRequire('./functions/rewards', 'rewards');
   achievementRoutes = tryRequire('./functions/achievements', 'achievements');
   shopRoutes = tryRequire('./functions/shop', 'shop');
+  sanctumRoutes = tryRequire('./functions/sanctum', 'sanctum');
 
   console.log('Loaded routes:', {
     user: !!userRoutes,
@@ -200,6 +201,7 @@ const loadRoutes = () => {
     rewards: !!rewardRoutes,
     achievements: !!achievementRoutes,
     shop: !!shopRoutes,
+    sanctum: !!sanctumRoutes,
   });
 };
 
@@ -591,6 +593,170 @@ app.post('/v1/expeditions/:id/claim', authenticateJWT, async (req, res) => {
     }
     else {
       res.json({ success: true, data: { message: 'Expedition claimed (stub)' } });
+    }
+  }
+  catch (error) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: error.message } });
+  }
+});
+
+// Sanctum routes
+const SANCTUM_ERROR_STATUS = {
+  NO_STAGE4_TOTEMS: 403,
+  NOT_FOUND: 404,
+  NOT_ASCENDED: 400,
+  NO_AVAILABLE_SEAT: 400,
+  NOT_SEATED: 400,
+  NOTHING_TO_CLAIM: 400,
+  ALREADY_SEATED: 409,
+  ON_EXPEDITION: 409,
+  ON_MISSION: 409,
+  INVALID_MISSION: 400,
+  INSUFFICIENT_ESSENCE: 400,
+  INSUFFICIENT_HAPPINESS: 400,
+  ALREADY_ON_MISSION: 409,
+  MISSION_NOT_FOUND: 404,
+  MISSION_NOT_COMPLETE: 400,
+  INSUFFICIENT_STAGE: 400,
+};
+
+app.get('/v1/sanctum', authenticateJWT, async (req, res) => {
+  try {
+    if (sanctumRoutes?.getSanctum) {
+      const result = await sanctumRoutes.getSanctum(req.user);
+      res.json(result);
+    }
+    else {
+      res.json({ success: true, data: { seats: [], filledSeats: 0, maxSeats: 0, totalPendingEarnings: 0 } });
+    }
+  }
+  catch (error) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: error.message } });
+  }
+});
+
+app.post('/v1/sanctum/seat', authenticateJWT, async (req, res) => {
+  try {
+    if (sanctumRoutes?.seatTotem) {
+      const result = await sanctumRoutes.seatTotem(req.user, req.body);
+      if (!result.success && result.error?.code) {
+        const status = SANCTUM_ERROR_STATUS[result.error.code] || 400;
+        return res.status(status).json(result);
+      }
+      res.json(result);
+    }
+    else {
+      res.json({ success: true, data: { message: 'Seat totem (stub)' } });
+    }
+  }
+  catch (error) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: error.message } });
+  }
+});
+
+app.post('/v1/sanctum/unseat', authenticateJWT, async (req, res) => {
+  try {
+    if (sanctumRoutes?.unseatTotem) {
+      const result = await sanctumRoutes.unseatTotem(req.user, req.body);
+      if (!result.success && result.error?.code) {
+        const status = SANCTUM_ERROR_STATUS[result.error.code] || 400;
+        return res.status(status).json(result);
+      }
+      res.json(result);
+    }
+    else {
+      res.json({ success: true, data: { message: 'Unseat totem (stub)' } });
+    }
+  }
+  catch (error) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: error.message } });
+  }
+});
+
+app.post('/v1/sanctum/claim', authenticateJWT, async (req, res) => {
+  try {
+    if (sanctumRoutes?.claimSanctum) {
+      const result = await sanctumRoutes.claimSanctum(req.user);
+      if (!result.success && result.error?.code) {
+        const status = SANCTUM_ERROR_STATUS[result.error.code] || 400;
+        return res.status(status).json(result);
+      }
+      res.json(result);
+    }
+    else {
+      res.json({ success: true, data: { message: 'Claim sanctum (stub)' } });
+    }
+  }
+  catch (error) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: error.message } });
+  }
+});
+
+app.get('/v1/sanctum/missions', authenticateJWT, async (req, res) => {
+  try {
+    if (sanctumRoutes?.getCouncilMissions) {
+      const result = await sanctumRoutes.getCouncilMissions(req.user);
+      res.json(result);
+    }
+    else {
+      res.json({ success: true, data: { message: 'Council missions (stub)' } });
+    }
+  }
+  catch (error) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: error.message } });
+  }
+});
+
+app.post('/v1/sanctum/missions/start', authenticateJWT, async (req, res) => {
+  try {
+    if (sanctumRoutes?.startCouncilMission) {
+      const result = await sanctumRoutes.startCouncilMission(req.user, req.body);
+      if (!result.success && result.error?.code) {
+        const status = SANCTUM_ERROR_STATUS[result.error.code] || 400;
+        return res.status(status).json(result);
+      }
+      res.json(result);
+    }
+    else {
+      res.json({ success: true, data: { message: 'Start mission (stub)' } });
+    }
+  }
+  catch (error) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: error.message } });
+  }
+});
+
+app.post('/v1/sanctum/missions/claim', authenticateJWT, async (req, res) => {
+  try {
+    if (sanctumRoutes?.claimCouncilMission) {
+      const result = await sanctumRoutes.claimCouncilMission(req.user, req.body);
+      if (!result.success && result.error?.code) {
+        const status = SANCTUM_ERROR_STATUS[result.error.code] || 400;
+        return res.status(status).json(result);
+      }
+      res.json(result);
+    }
+    else {
+      res.json({ success: true, data: { message: 'Claim mission (stub)' } });
+    }
+  }
+  catch (error) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: error.message } });
+  }
+});
+
+app.post('/v1/sanctum/missions/cancel', authenticateJWT, async (req, res) => {
+  try {
+    if (sanctumRoutes?.cancelCouncilMission) {
+      const result = await sanctumRoutes.cancelCouncilMission(req.user, req.body);
+      if (!result.success && result.error?.code) {
+        const status = SANCTUM_ERROR_STATUS[result.error.code] || 400;
+        return res.status(status).json(result);
+      }
+      res.json(result);
+    }
+    else {
+      res.json({ success: true, data: { message: 'Cancel mission (stub)' } });
     }
   }
   catch (error) {

--- a/src/common/db-client.js
+++ b/src/common/db-client.js
@@ -471,7 +471,7 @@ async function addEssence(userId, amount, { type = 'reward', ref = null } = {}) 
  * @param {string} userId
  * @param {{ lesser?: number, greater?: number, ancient?: number }} runes
  */
-async function addRunes(userId, runes) {
+async function addRunes(userId, runes, { type = 'reward', ref = null } = {}) {
   const lesser = runes.lesser || 0;
   const greater = runes.greater || 0;
   const ancient = runes.ancient || 0;
@@ -508,6 +508,9 @@ async function addRunes(userId, runes) {
 
     const response = await docClient.send(command);
     const newBalances = response.Attributes?.currencies?.runes || { lesser: 0, greater: 0, ancient: 0 };
+
+    await logRuneTransaction(userId, { lesser, greater, ancient }, newBalances, type, ref);
+
     return { success: true, newBalances };
   }
   catch (err) {
@@ -529,9 +532,32 @@ async function addRunes(userId, runes) {
       });
       const response = await docClient.send(initCommand);
       const newBalances = response.Attributes?.currencies?.runes || { lesser: 0, greater: 0, ancient: 0 };
+
+      await logRuneTransaction(userId, { lesser, greater, ancient }, newBalances, type, ref);
+
       return { success: true, newBalances };
     }
     throw err;
+  }
+}
+
+/**
+ * Log individual rune transactions (one per rune type that was awarded)
+ */
+async function logRuneTransaction(userId, runesAdded, newBalances, type, ref) {
+  const runeTypes = ['lesser', 'greater', 'ancient'];
+  for (const runeType of runeTypes) {
+    const amount = runesAdded[runeType] || 0;
+    if (amount > 0) {
+      await logTransaction(userId, {
+        type,
+        currency: `rune_${runeType}`,
+        amount,
+        balanceBefore: (newBalances[runeType] || 0) - amount,
+        balanceAfter: newBalances[runeType] || 0,
+        ref,
+      });
+    }
   }
 }
 

--- a/src/common/totem-utils.js
+++ b/src/common/totem-utils.js
@@ -1,0 +1,47 @@
+/**
+ * Totem Availability Utilities
+ *
+ * Shared busy-check helpers used by game actions, expeditions, forge, and sanctum.
+ * Centralizes the logic for determining if a totem can perform various activities.
+ */
+
+/**
+ * Check if a totem is available for game actions (Feed, Train, Treat).
+ * Seated totems CAN perform actions (they're resting at the sanctum).
+ * Totems on a Council Mission CANNOT (they're away).
+ *
+ * @param {object} totem - Totem record from DynamoDB
+ * @returns {{ available: boolean, error?: { code: string, message: string } }}
+ */
+function checkActionAvailability(totem) {
+  if (totem.sanctum?.onMission) {
+    return {
+      available: false,
+      error: { code: 'ON_COUNCIL_MISSION', message: 'Totem is away on a Council Mission' },
+    };
+  }
+  return { available: true };
+}
+
+/**
+ * Check if a totem is available for expeditions or forge.
+ * Seated totems CANNOT go on expeditions or be forged (they're locked).
+ * Totems on active expeditions also CANNOT.
+ *
+ * @param {object} totem - Totem record from DynamoDB
+ * @returns {{ available: boolean, error?: { code: string, message: string } }}
+ */
+function checkExpeditionAvailability(totem) {
+  if (totem.sanctum?.seated) {
+    return {
+      available: false,
+      error: { code: 'ON_COUNCIL', message: 'Totem is seated on the Elder Council' },
+    };
+  }
+  return { available: true };
+}
+
+module.exports = {
+  checkActionAvailability,
+  checkExpeditionAvailability,
+};

--- a/src/functions/game-actions/feed.js
+++ b/src/functions/game-actions/feed.js
@@ -57,7 +57,14 @@ async function feed(user, totemId) {
     };
   }
 
-  // 3. Check time window (feed uses 8-hour UTC windows, not cooldown)
+  // 3. Check totem availability (blocks if on Council Mission)
+  const { checkActionAvailability } = require('../../common/totem-utils');
+  const availability = checkActionAvailability(totem);
+  if (!availability.available) {
+    return { success: false, error: availability.error };
+  }
+
+  // 4. Check time window (feed uses 8-hour UTC windows, not cooldown)
   const feedHistory = totem.feedHistory || [];
   const windowStatus = checkFeedTimeWindow(feedHistory);
 

--- a/src/functions/game-actions/train.js
+++ b/src/functions/game-actions/train.js
@@ -55,7 +55,14 @@ async function train(user, totemId) {
     };
   }
 
-  // 3. Check cooldown (train has cooldown: 0, so this should always pass)
+  // 3. Check totem availability (blocks if on Council Mission)
+  const { checkActionAvailability } = require('../../common/totem-utils');
+  const availability = checkActionAvailability(totem);
+  if (!availability.available) {
+    return { success: false, error: availability.error };
+  }
+
+  // 4. Check cooldown (train has cooldown: 0, so this should always pass)
   const cooldownStatus = checkCooldown(totem.cooldowns?.train, actionType);
 
   if (cooldownStatus.onCooldown) {

--- a/src/functions/game-actions/treat.js
+++ b/src/functions/game-actions/treat.js
@@ -53,7 +53,14 @@ async function treat(user, totemId) {
     };
   }
 
-  // 3. Check cooldown (treat has 4-hour cooldown)
+  // 3. Check totem availability (blocks if on Council Mission)
+  const { checkActionAvailability } = require('../../common/totem-utils');
+  const availability = checkActionAvailability(totem);
+  if (!availability.available) {
+    return { success: false, error: availability.error };
+  }
+
+  // 4. Check cooldown (treat has 4-hour cooldown)
   const cooldownStatus = checkCooldown(totem.cooldowns?.treat, actionType);
 
   if (cooldownStatus.onCooldown) {

--- a/src/functions/sanctum/claim.js
+++ b/src/functions/sanctum/claim.js
@@ -1,0 +1,31 @@
+/**
+ * Claim Sanctum Earnings Handler
+ *
+ * POST /v1/sanctum/claim
+ *
+ * Claims accumulated Essence from all seated totems. Uses atomic
+ * transaction to prevent double-claiming.
+ */
+
+const sanctumService = require('../../services/sanctum-service');
+
+/**
+ * Claim sanctum earnings
+ *
+ * @param {object} user - Authenticated user { userId }
+ * @returns {object} - Claim result with earnings breakdown
+ */
+async function claimSanctum(user) {
+  try {
+    const result = await sanctumService.claimSanctum(user.userId);
+    return result;
+  } catch (error) {
+    console.error('Failed to claim sanctum earnings:', error);
+    return {
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: error.message },
+    };
+  }
+}
+
+module.exports = { claimSanctum };

--- a/src/functions/sanctum/get-sanctum.js
+++ b/src/functions/sanctum/get-sanctum.js
@@ -1,0 +1,31 @@
+/**
+ * Get Sanctum Handler
+ *
+ * GET /v1/sanctum
+ *
+ * Returns the user's full Elder Sanctum state including all seats,
+ * pending earnings, and max seat count.
+ */
+
+const sanctumService = require('../../services/sanctum-service');
+
+/**
+ * Get the user's sanctum state
+ *
+ * @param {object} user - Authenticated user { userId }
+ * @returns {object} - Sanctum state
+ */
+async function getSanctum(user) {
+  try {
+    const result = await sanctumService.getSanctum(user.userId);
+    return { success: true, data: result };
+  } catch (error) {
+    console.error('Failed to get sanctum:', error);
+    return {
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: error.message },
+    };
+  }
+}
+
+module.exports = { getSanctum };

--- a/src/functions/sanctum/index.js
+++ b/src/functions/sanctum/index.js
@@ -1,0 +1,33 @@
+/**
+ * Sanctum API Handlers
+ *
+ * Routes:
+ * - GET  /v1/sanctum                - Get sanctum state (seats, earnings, max seats)
+ * - POST /v1/sanctum/seat           - Seat a Stage 4 totem
+ * - POST /v1/sanctum/unseat         - Remove a totem from the sanctum
+ * - POST /v1/sanctum/claim          - Claim accumulated Essence earnings
+ * - GET  /v1/sanctum/missions       - Get available council missions
+ * - POST /v1/sanctum/missions/start - Start a council mission
+ * - POST /v1/sanctum/missions/claim - Claim council mission rewards
+ * - POST /v1/sanctum/missions/cancel - Cancel a council mission
+ */
+
+const { getSanctum } = require('./get-sanctum');
+const { seatTotem } = require('./seat');
+const { unseatTotem } = require('./unseat');
+const { claimSanctum } = require('./claim');
+const { getCouncilMissions } = require('./missions');
+const { startCouncilMission } = require('./mission-start');
+const { claimCouncilMission } = require('./mission-claim');
+const { cancelCouncilMission } = require('./mission-cancel');
+
+module.exports = {
+  getSanctum,
+  seatTotem,
+  unseatTotem,
+  claimSanctum,
+  getCouncilMissions,
+  startCouncilMission,
+  claimCouncilMission,
+  cancelCouncilMission,
+};

--- a/src/functions/sanctum/mission-cancel.js
+++ b/src/functions/sanctum/mission-cancel.js
@@ -1,0 +1,43 @@
+/**
+ * Cancel Council Mission Handler
+ *
+ * POST /v1/sanctum/missions/cancel
+ *
+ * Body: { totemId }
+ *
+ * Cancels an active council mission. No refund is given and no rewards
+ * are earned. The totem is freed from the mission.
+ */
+
+const sanctumService = require('../../services/sanctum-service');
+
+/**
+ * Cancel an active council mission
+ *
+ * @param {object} user - Authenticated user { userId }
+ * @param {object} body - Request body { totemId }
+ * @returns {object} - Cancellation result
+ */
+async function cancelCouncilMission(user, body) {
+  const { totemId } = body || {};
+
+  if (!totemId) {
+    return {
+      success: false,
+      error: { code: 'MISSING_PARAM', message: 'totemId is required' },
+    };
+  }
+
+  try {
+    const result = await sanctumService.cancelCouncilMission(user.userId, totemId);
+    return result;
+  } catch (error) {
+    console.error('Failed to cancel council mission:', error);
+    return {
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: error.message },
+    };
+  }
+}
+
+module.exports = { cancelCouncilMission };

--- a/src/functions/sanctum/mission-claim.js
+++ b/src/functions/sanctum/mission-claim.js
@@ -1,0 +1,42 @@
+/**
+ * Claim Council Mission Handler
+ *
+ * POST /v1/sanctum/missions/claim
+ *
+ * Body: { totemId }
+ *
+ * Claims rewards from a completed council mission. Awards XP and Essence.
+ */
+
+const sanctumService = require('../../services/sanctum-service');
+
+/**
+ * Claim council mission rewards
+ *
+ * @param {object} user - Authenticated user { userId }
+ * @param {object} body - Request body { totemId }
+ * @returns {object} - Claim result with rewards
+ */
+async function claimCouncilMission(user, body) {
+  const { totemId } = body || {};
+
+  if (!totemId) {
+    return {
+      success: false,
+      error: { code: 'MISSING_PARAM', message: 'totemId is required' },
+    };
+  }
+
+  try {
+    const result = await sanctumService.claimCouncilMission(user.userId, totemId);
+    return result;
+  } catch (error) {
+    console.error('Failed to claim council mission:', error);
+    return {
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: error.message },
+    };
+  }
+}
+
+module.exports = { claimCouncilMission };

--- a/src/functions/sanctum/mission-start.js
+++ b/src/functions/sanctum/mission-start.js
@@ -1,0 +1,50 @@
+/**
+ * Start Council Mission Handler
+ *
+ * POST /v1/sanctum/missions/start
+ *
+ * Body: { totemId, missionType }
+ *
+ * Starts a council mission for a seated totem. Deducts Essence and
+ * happiness costs, creates a timed mission record.
+ */
+
+const sanctumService = require('../../services/sanctum-service');
+
+/**
+ * Start a council mission
+ *
+ * @param {object} user - Authenticated user { userId }
+ * @param {object} body - Request body { totemId, missionType }
+ * @returns {object} - Mission start result
+ */
+async function startCouncilMission(user, body) {
+  const { totemId, missionType } = body || {};
+
+  if (!totemId) {
+    return {
+      success: false,
+      error: { code: 'MISSING_PARAM', message: 'totemId is required' },
+    };
+  }
+
+  if (!missionType) {
+    return {
+      success: false,
+      error: { code: 'MISSING_PARAM', message: 'missionType is required' },
+    };
+  }
+
+  try {
+    const result = await sanctumService.startCouncilMission(user.userId, totemId, missionType);
+    return result;
+  } catch (error) {
+    console.error('Failed to start council mission:', error);
+    return {
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: error.message },
+    };
+  }
+}
+
+module.exports = { startCouncilMission };

--- a/src/functions/sanctum/missions.js
+++ b/src/functions/sanctum/missions.js
@@ -1,0 +1,30 @@
+/**
+ * Get Council Missions Handler
+ *
+ * GET /v1/sanctum/missions
+ *
+ * Returns all available council missions grouped by tier.
+ */
+
+const sanctumService = require('../../services/sanctum-service');
+
+/**
+ * Get available council missions
+ *
+ * @param {object} user - Authenticated user { userId }
+ * @returns {object} - Missions grouped by tier
+ */
+async function getCouncilMissions(user) {
+  try {
+    const missions = sanctumService.getCouncilMissions();
+    return { success: true, data: missions };
+  } catch (error) {
+    console.error('Failed to get council missions:', error);
+    return {
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: error.message },
+    };
+  }
+}
+
+module.exports = { getCouncilMissions };

--- a/src/functions/sanctum/seat.js
+++ b/src/functions/sanctum/seat.js
@@ -1,0 +1,66 @@
+/**
+ * Seat Totem Handler
+ *
+ * POST /v1/sanctum/seat
+ *
+ * Body: { totemId, seatIndex? }
+ *
+ * Seats a Stage 4 totem in the Elder Sanctum. If seatIndex is omitted,
+ * auto-assigns the first available seat.
+ */
+
+const sanctumService = require('../../services/sanctum-service');
+
+/**
+ * Seat a totem in the sanctum
+ *
+ * @param {object} user - Authenticated user { userId }
+ * @param {object} body - Request body { totemId, seatIndex? }
+ * @returns {object} - Result with updated sanctum state
+ */
+async function seatTotem(user, body) {
+  const { totemId, seatIndex } = body || {};
+
+  // Validate required params
+  if (!totemId) {
+    return {
+      success: false,
+      error: { code: 'MISSING_PARAM', message: 'totemId is required' },
+    };
+  }
+
+  if (!totemId.startsWith('ttm_')) {
+    return {
+      success: false,
+      error: { code: 'INVALID_ID', message: 'Invalid totem ID format' },
+    };
+  }
+
+  // Validate seatIndex if provided
+  if (seatIndex !== undefined && seatIndex !== null) {
+    const idx = Number(seatIndex);
+    if (!Number.isInteger(idx) || idx < 0 || idx > 2) {
+      return {
+        success: false,
+        error: { code: 'INVALID_PARAM', message: 'seatIndex must be 0, 1, or 2' },
+      };
+    }
+  }
+
+  try {
+    const result = await sanctumService.seatTotem(
+      user.userId,
+      totemId,
+      seatIndex !== undefined && seatIndex !== null ? Number(seatIndex) : undefined,
+    );
+    return result;
+  } catch (error) {
+    console.error('Failed to seat totem:', error);
+    return {
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: error.message },
+    };
+  }
+}
+
+module.exports = { seatTotem };

--- a/src/functions/sanctum/unseat.js
+++ b/src/functions/sanctum/unseat.js
@@ -1,0 +1,51 @@
+/**
+ * Unseat Totem Handler
+ *
+ * POST /v1/sanctum/unseat
+ *
+ * Body: { totemId }
+ *
+ * Removes a totem from the Elder Sanctum. The totem must not be on a
+ * council mission. Any unclaimed earnings are forfeited.
+ */
+
+const sanctumService = require('../../services/sanctum-service');
+
+/**
+ * Unseat a totem from the sanctum
+ *
+ * @param {object} user - Authenticated user { userId }
+ * @param {object} body - Request body { totemId }
+ * @returns {object} - Result with updated sanctum state
+ */
+async function unseatTotem(user, body) {
+  const { totemId } = body || {};
+
+  // Validate required params
+  if (!totemId) {
+    return {
+      success: false,
+      error: { code: 'MISSING_PARAM', message: 'totemId is required' },
+    };
+  }
+
+  if (!totemId.startsWith('ttm_')) {
+    return {
+      success: false,
+      error: { code: 'INVALID_ID', message: 'Invalid totem ID format' },
+    };
+  }
+
+  try {
+    const result = await sanctumService.unseatTotem(user.userId, totemId);
+    return result;
+  } catch (error) {
+    console.error('Failed to unseat totem:', error);
+    return {
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: error.message },
+    };
+  }
+}
+
+module.exports = { unseatTotem };

--- a/src/functions/totems/index.js
+++ b/src/functions/totems/index.js
@@ -105,7 +105,7 @@ function transformTotemForApi(totem) {
       wisdom: totem.stats?.wisdom || 5,
       nickname: totem.nickname || null,  // User-customizable name (optional)
       prestigeLevel: totem.prestigeLevel || 0,
-      isStaked: false, // Web2 doesn't have staking
+      ...(totem.sanctum && { sanctum: totem.sanctum }),
     },
 
     // Action tracking (used for cooldowns)

--- a/src/routes/api-docs.js
+++ b/src/routes/api-docs.js
@@ -2180,6 +2180,329 @@
  */
 
 // ============================================
+// Sanctum Endpoints (8)
+// ============================================
+
+/**
+ * @swagger
+ * /v1/sanctum:
+ *   get:
+ *     tags: [Sanctum]
+ *     summary: Get sanctum state
+ *     description: Returns the user's Elder Sanctum state including seated totems, passive accumulation, and active missions
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Sanctum state
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     seats:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           seatIndex: { type: number }
+ *                           totemId: { type: string }
+ *                           totemName: { type: string }
+ *                           species: { type: string }
+ *                           seatedAt: { type: string }
+ *                           lastClaimedAt: { type: string }
+ *                           earnings: { type: number }
+ *                           tenureHours: { type: number }
+ *                           tenureMultiplier: { type: number }
+ *                           onMission: { type: boolean }
+ *                     maxSeats: { type: number }
+ *                     totalAccumulated: { type: number }
+ */
+
+/**
+ * @swagger
+ * /v1/sanctum/seat:
+ *   post:
+ *     tags: [Sanctum]
+ *     summary: Seat a totem in the sanctum
+ *     description: Place a Stage 4+ totem in an available sanctum seat to begin passive Essence accumulation. Totem cannot be on an expedition.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [totemId]
+ *             properties:
+ *               totemId:
+ *                 type: string
+ *                 description: ID of Stage 4+ totem to seat
+ *               seatIndex:
+ *                 type: number
+ *                 description: Optional specific seat index (auto-assigned if omitted)
+ *     responses:
+ *       200:
+ *         description: Totem seated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     seats: { type: array, items: { type: object } }
+ *                     maxSeats: { type: number }
+ *                     totalAccumulated: { type: number }
+ *       400:
+ *         description: Totem not found, below Stage 4, already seated, on expedition, or no available seat
+ */
+
+/**
+ * @swagger
+ * /v1/sanctum/unseat:
+ *   post:
+ *     tags: [Sanctum]
+ *     summary: Unseat a totem from the sanctum
+ *     description: Remove a seated totem from the sanctum. Resets tenure multiplier. Cannot unseat while totem is on a council mission.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [totemId]
+ *             properties:
+ *               totemId:
+ *                 type: string
+ *                 description: ID of the seated totem to remove
+ *     responses:
+ *       200:
+ *         description: Totem unseated successfully
+ *       400:
+ *         description: Totem not seated or currently on a mission
+ */
+
+/**
+ * @swagger
+ * /v1/sanctum/claim:
+ *   post:
+ *     tags: [Sanctum]
+ *     summary: Claim accumulated Essence
+ *     description: Claim all passively accumulated Essence from seated totems. Earnings are based on time since last claim and tenure multiplier (up to 1.5x at 30 days). Accumulation caps at 168 hours.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Essence claimed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     totalClaimed: { type: number }
+ *                     newEssenceBalance: { type: number }
+ *                     breakdown:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           seatIndex: { type: number }
+ *                           totemName: { type: string }
+ *                           earned: { type: number }
+ *                     claimedAt: { type: string }
+ *       400:
+ *         description: No seats or nothing to claim (less than 1 Essence)
+ */
+
+/**
+ * @swagger
+ * /v1/sanctum/missions:
+ *   get:
+ *     tags: [Sanctum]
+ *     summary: List available council missions
+ *     description: Returns all 9 council missions grouped by tier (governance, diplomacy, legacy) with costs, durations, and rewards
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Council missions grouped by tier
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     governance:
+ *                       type: array
+ *                       description: "Stage 4+ missions (2-4hr, low cost)"
+ *                       items: { $ref: '#/components/schemas/CouncilMission' }
+ *                     diplomacy:
+ *                       type: array
+ *                       description: "Stage 5 missions (6-8hr, medium cost)"
+ *                       items: { $ref: '#/components/schemas/CouncilMission' }
+ *                     legacy:
+ *                       type: array
+ *                       description: "Stage 5 missions (12-24hr, high cost)"
+ *                       items: { $ref: '#/components/schemas/CouncilMission' }
+ */
+
+/**
+ * @swagger
+ * /v1/sanctum/missions/start:
+ *   post:
+ *     tags: [Sanctum]
+ *     summary: Start a council mission
+ *     description: Send a seated totem on a council mission. Costs Essence and happiness. Totem earns XP and rune drops on completion.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [totemId, missionType]
+ *             properties:
+ *               totemId:
+ *                 type: string
+ *                 description: ID of the seated totem
+ *               missionType:
+ *                 type: string
+ *                 description: "Mission ID (e.g., cm_decree-of-wisdom, cm_peace-summit)"
+ *                 example: cm_decree-of-wisdom
+ *     responses:
+ *       200:
+ *         description: Mission started
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     mission:
+ *                       type: object
+ *                       properties:
+ *                         missionType: { type: string }
+ *                         name: { type: string }
+ *                         tier: { type: string }
+ *                         duration: { type: number, description: "Duration in seconds" }
+ *                         startedAt: { type: string }
+ *                         endsAt: { type: string }
+ *                     newEssenceBalance: { type: number }
+ *       400:
+ *         description: Invalid mission, totem not seated, already on mission, insufficient stage/Essence/happiness
+ */
+
+/**
+ * @swagger
+ * /v1/sanctum/missions/claim:
+ *   post:
+ *     tags: [Sanctum]
+ *     summary: Claim completed council mission
+ *     description: Claim rewards from a completed council mission. Awards XP to totem and rolls for rune drops based on mission tier.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [totemId]
+ *             properties:
+ *               totemId:
+ *                 type: string
+ *                 description: ID of the totem with a completed mission
+ *     responses:
+ *       200:
+ *         description: Mission rewards claimed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     rewards:
+ *                       type: object
+ *                       properties:
+ *                         xp: { type: number }
+ *                         runesEarned:
+ *                           type: object
+ *                           properties:
+ *                             lesser: { type: number }
+ *                             greater: { type: number }
+ *                             ancient: { type: number }
+ *                     missionType: { type: string }
+ *                     missionName: { type: string }
+ *                     totemId: { type: string }
+ *                     newRuneBalances: { type: object, nullable: true }
+ *       400:
+ *         description: No active mission or mission not yet complete
+ */
+
+/**
+ * @swagger
+ * /v1/sanctum/missions/cancel:
+ *   post:
+ *     tags: [Sanctum]
+ *     summary: Cancel an active council mission
+ *     description: Cancel a council mission in progress. No Essence refund and no rewards are given. Totem remains seated.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [totemId]
+ *             properties:
+ *               totemId:
+ *                 type: string
+ *                 description: ID of the totem with an active mission to cancel
+ *     responses:
+ *       200:
+ *         description: Mission cancelled
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     cancelled: { type: boolean, example: true }
+ *                     missionType: { type: string }
+ *                     totemId: { type: string }
+ *       400:
+ *         description: No active mission found
+ */
+
+// ============================================
 // Health Check (1)
 // ============================================
 

--- a/src/services/achievements-service.js
+++ b/src/services/achievements-service.js
@@ -50,6 +50,12 @@ const ACHIEVEMENT_IDS = {
   RARE_FORGER: 'ach_rare-forger',
   EPIC_FORGER: 'ach_epic-forger',
   LEGENDARY_FORGER: 'ach_legendary-forger',
+  FIRST_ELDER: 'ach_first-elder',
+  FULL_COUNCIL: 'ach_full-council',
+  SANCTUM_CLAIM: 'ach_sanctum-claim',
+  TENURE_MASTER: 'ach_tenure-master',
+  COUNCIL_MISSIONS: 'ach_council-missions',
+  FOUNDING_RITUAL: 'ach_founding-ritual',
 };
 
 // =============================================================================
@@ -89,6 +95,10 @@ const TRIGGER_TO_ACHIEVEMENTS = {
     ACHIEVEMENT_IDS.LEGENDARY_COLLECTOR,
     ACHIEVEMENT_IDS.COLLECTOR_PROGRESSION,
   ],
+  ELDER_SEATED: [ACHIEVEMENT_IDS.FIRST_ELDER, ACHIEVEMENT_IDS.FULL_COUNCIL],
+  SANCTUM_CLAIMED: [ACHIEVEMENT_IDS.SANCTUM_CLAIM],
+  TENURE_CHECK: [ACHIEVEMENT_IDS.TENURE_MASTER],
+  MISSION_COMPLETED: [ACHIEVEMENT_IDS.COUNCIL_MISSIONS, ACHIEVEMENT_IDS.FOUNDING_RITUAL],
 };
 
 // =============================================================================
@@ -107,6 +117,10 @@ const ACHIEVEMENT_MILESTONES = {
   [ACHIEVEMENT_IDS.FUSION_PROGRESSION]: [1, 5, 10, 25, 50, 100, 250],
   [ACHIEVEMENT_IDS.PURE_FUSION]: [1, 3, 5, 10, 25],
   [ACHIEVEMENT_IDS.WILD_FUSION]: [1, 3, 5, 10, 25],
+  [ACHIEVEMENT_IDS.FULL_COUNCIL]: [3],
+  [ACHIEVEMENT_IDS.SANCTUM_CLAIM]: [1, 10, 50, 100, 500],
+  [ACHIEVEMENT_IDS.TENURE_MASTER]: [7, 14, 30],
+  [ACHIEVEMENT_IDS.COUNCIL_MISSIONS]: [5, 25, 50, 100, 500],
 };
 
 const ONETIME_ACHIEVEMENTS = [
@@ -118,6 +132,8 @@ const ONETIME_ACHIEVEMENTS = [
   ACHIEVEMENT_IDS.RARE_FORGER,
   ACHIEVEMENT_IDS.EPIC_FORGER,
   ACHIEVEMENT_IDS.LEGENDARY_FORGER,
+  ACHIEVEMENT_IDS.FIRST_ELDER,
+  ACHIEVEMENT_IDS.FOUNDING_RITUAL,
 ];
 
 // Rarity IDs (from totem data)
@@ -179,6 +195,16 @@ const ONE_TIME_REWARDS = {
     essence: 1000,
     xp: 150,
     name: 'Legendary Forger',
+  },
+  [ACHIEVEMENT_IDS.FIRST_ELDER]: {
+    essence: 50,
+    xp: 100,
+    name: 'First Among Equals',
+  },
+  [ACHIEVEMENT_IDS.FOUNDING_RITUAL]: {
+    essence: 100,
+    xp: 150,
+    name: 'World Founder',
   },
 };
 
@@ -268,6 +294,28 @@ const MILESTONE_REWARDS = {
     { essence: 750, xp: 100, name: 'Wild Alchemist' },       // 5 wild fusions
     { essence: 1500, xp: 150, name: 'Entropy Weaver' },      // 10 wild fusions
     { essence: 3000, xp: 200, name: 'Primordial Shaper' },   // 25 wild fusions
+  ],
+  [ACHIEVEMENT_IDS.FULL_COUNCIL]: [
+    { essence: 100, xp: 200, name: 'Full Council' },          // 3 seats filled
+  ],
+  [ACHIEVEMENT_IDS.SANCTUM_CLAIM]: [
+    { essence: 25, xp: 25, name: 'First Tithe' },             // 1 claim
+    { essence: 50, xp: 50, name: 'Tithe Collector' },         // 10 claims
+    { essence: 100, xp: 100, name: 'Sanctum Treasurer' },     // 50 claims
+    { essence: 200, xp: 200, name: 'Grand Treasurer' },       // 100 claims
+    { essence: 500, xp: 400, name: 'Eternal Treasurer' },     // 500 claims
+  ],
+  [ACHIEVEMENT_IDS.TENURE_MASTER]: [
+    { essence: 50, xp: 0, name: 'Week Watch' },               // 7 days
+    { essence: 100, xp: 0, name: 'Fortnight Keeper' },        // 14 days
+    { essence: 200, xp: 0, name: 'Long Reign' },              // 30 days
+  ],
+  [ACHIEVEMENT_IDS.COUNCIL_MISSIONS]: [
+    { essence: 25, xp: 50, name: 'Mission Initiate' },        // 5 missions
+    { essence: 50, xp: 100, name: 'Council Veteran' },        // 25 missions
+    { essence: 100, xp: 200, name: 'Elder Diplomat' },        // 50 missions
+    { essence: 200, xp: 400, name: 'Grand Elder' },           // 100 missions
+    { essence: 500, xp: 750, name: 'Eternal Elder' },         // 500 missions
   ],
 };
 
@@ -722,6 +770,33 @@ async function checkAchievement(userId, trigger, data = {}) {
           }
           break;
 
+        case 'ELDER_SEATED':
+          if (achievementId === ACHIEVEMENT_IDS.FIRST_ELDER) {
+            value = 1; // One-time: first totem seated
+          }
+          else if (achievementId === ACHIEVEMENT_IDS.FULL_COUNCIL) {
+            value = data.totalSeatedCount || 0;
+          }
+          break;
+
+        case 'SANCTUM_CLAIMED':
+          value = data.totalClaimCount || 0;
+          break;
+
+        case 'TENURE_CHECK':
+          value = data.tenureDays || 0;
+          break;
+
+        case 'MISSION_COMPLETED':
+          if (achievementId === ACHIEVEMENT_IDS.FOUNDING_RITUAL) {
+            // Only triggers for the founding-ritual mission
+            value = data.missionType === 'cm_founding-ritual' ? 1 : 0;
+          }
+          else if (achievementId === ACHIEVEMENT_IDS.COUNCIL_MISSIONS) {
+            value = data.totalMissionCount || 0;
+          }
+          break;
+
         default:
           value = data.value || 0;
       }
@@ -859,6 +934,37 @@ async function onTotemFused(userId, { isPureFusion, newRarityId, totalFusionCoun
   });
 }
 
+/**
+ * Call when an elder totem is seated in the sanctum
+ * @param {string} userId - User ID
+ * @param {object} options - Options object
+ * @param {number} options.totalSeatedCount - Total seats now occupied (after seating)
+ */
+async function onElderSeated(userId, { totalSeatedCount }) {
+  return checkAchievement(userId, 'ELDER_SEATED', { totalSeatedCount });
+}
+
+/**
+ * Call when sanctum Essence is claimed
+ * @param {string} userId - User ID
+ * @param {object} options - Options object
+ * @param {number} options.totalClaimCount - Total sanctum claims by the user
+ */
+async function onSanctumClaimed(userId, { totalClaimCount }) {
+  return checkAchievement(userId, 'SANCTUM_CLAIMED', { totalClaimCount });
+}
+
+/**
+ * Call when a council mission is completed and claimed
+ * @param {string} userId - User ID
+ * @param {object} options - Options object
+ * @param {string} options.missionType - Mission type ID (e.g. 'cm_founding-ritual')
+ * @param {number} options.totalMissionCount - Total council missions completed by user
+ */
+async function onMissionCompleted(userId, { missionType, totalMissionCount }) {
+  return checkAchievement(userId, 'MISSION_COMPLETED', { missionType, totalMissionCount });
+}
+
 // =============================================================================
 // EXPORTS
 // =============================================================================
@@ -895,4 +1001,7 @@ module.exports = {
   onChallengeCompleted,
   onExpeditionCompleted,
   onTotemFused,
+  onElderSeated,
+  onSanctumClaimed,
+  onMissionCompleted,
 };

--- a/src/services/challenges-service.js
+++ b/src/services/challenges-service.js
@@ -35,6 +35,7 @@ const {
 
 const { onChallengeCompleted } = require('./achievements-service');
 const { checkEvolutionRequirements } = require('../functions/game-actions/helpers');
+const { checkActionAvailability } = require('../common/totem-utils');
 
 // =============================================================================
 // CHALLENGE DEFINITIONS (10 Challenges - synced from frontend challenges.json)
@@ -411,7 +412,13 @@ async function completeChallenge(userId, challengeId, totemId, score) {
     };
   }
 
-  // 5. Check requirements (stage + stats)
+  // 5. Check if totem is available (not on council mission)
+  const availCheck = checkActionAvailability(totem);
+  if (!availCheck.available) {
+    return { success: false, error: availCheck.error };
+  }
+
+  // 6. Check requirements (stage + stats)
   const reqCheck = checkRequirements(totem, challenge);
   if (!reqCheck.qualified) {
     return {

--- a/src/services/expeditions-service.js
+++ b/src/services/expeditions-service.js
@@ -650,10 +650,22 @@ async function startExpedition(userId, totemId, expeditionId, totemIds) {
       };
     }
   }
+
+  // Resolve all team totems and check sanctum availability
+  const { checkExpeditionAvailability, checkActionAvailability } = require('../common/totem-utils');
   const teamTotems = [];
   for (const tid of allTotemIds) {
     const t = tid === totemId ? totem : await getTotem(userId, tid);
-    if (t) teamTotems.push({ id: tid, totem: t });
+    if (!t) continue;
+    const councilCheck = checkExpeditionAvailability(t);
+    if (!councilCheck.available) {
+      return { success: false, error: councilCheck.error };
+    }
+    const missionCheck = checkActionAvailability(t);
+    if (!missionCheck.available) {
+      return { success: false, error: missionCheck.error };
+    }
+    teamTotems.push({ id: tid, totem: t });
   }
 
   // Check happiness cost requirement for ALL team totems (validate before deducting anything)
@@ -845,7 +857,10 @@ async function claimExpeditionReward(userId, totemId) {
   let newRuneBalances = null;
   const hasRunes = (runesEarned.lesser || 0) + (runesEarned.greater || 0) + (runesEarned.ancient || 0) > 0;
   if (hasRunes) {
-    const runeResult = await addRunes(userId, runesEarned);
+    const runeResult = await addRunes(userId, runesEarned, {
+      type: 'reward_expedition',
+      ref: activeExpedition.expeditionId,
+    });
     if (runeResult.success) {
       newRuneBalances = runeResult.newBalances;
     }

--- a/src/services/sanctum-service.js
+++ b/src/services/sanctum-service.js
@@ -1,0 +1,996 @@
+/**
+ * Sanctum Service
+ *
+ * Handles the Elder Sanctum feature where Stage 4+ (Adult/Ascended) totems can be
+ * seated to passively earn Essence over time. Earnings scale with tenure.
+ *
+ * Key patterns:
+ * - Uses EXPEDITION_STATE table with SANCTUM# prefix for seat records
+ * - Totem records get a `sanctum` field when seated
+ * - Earnings are capped at 168 hours (7 days) to encourage regular claiming
+ * - Atomic claim via transactWrite to prevent double-spend
+ *
+ * Usage:
+ *   const sanctumService = require('./services/sanctum-service');
+ *   await sanctumService.seatTotem(userId, totemId, 0);
+ *   await sanctumService.claimSanctum(userId);
+ */
+
+const {
+  getItem,
+  putItem,
+  deleteItem,
+  queryItems,
+  getTotem,
+  updateTotem,
+  addRunes,
+  getUserTotems,
+  transactWrite,
+  TABLES,
+  userPK,
+  logTransaction,
+} = require('../common/db-client');
+
+const {
+  onElderSeated,
+  onSanctumClaimed,
+  onMissionCompleted,
+} = require('./achievements-service');
+
+const { SPECIES_DISPLAY_NAMES } = require('./totem-creation');
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Minimum XP to enter the Sanctum — Stage 4 in UI (internal stage 3, Adult) */
+const SANCTUM_MIN_XP = 3500;
+
+
+/** Maximum hours of earnings that can accumulate before claiming */
+const MAX_ACCUMULATION_HOURS = 168; // 7 days
+
+/** Base Essence per hour (before tenure multiplier) */
+const BASE_RATE_PER_HOUR = 0.5;
+
+/** Maximum number of seats possible */
+const MAX_SEATS = 3;
+
+// =============================================================================
+// Key Helpers
+// =============================================================================
+
+function sanctumPK(userId) {
+  return `SANCTUM#${userId}`;
+}
+
+function seatSK(seatIndex) {
+  return `SEAT#${seatIndex}`;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Get tenure multiplier based on hours seated
+ *
+ * Brackets:
+ *   0-24 hrs   = 1.0x
+ *   24-72 hrs  = 1.1x
+ *   72-168 hrs = 1.2x
+ *   168-336 hrs = 1.3x
+ *   336-720 hrs = 1.4x
+ *   720+ hrs   = 1.5x
+ *
+ * @param {number} tenureHours - Hours since totem was seated
+ * @returns {number} Multiplier between 1.0 and 1.5
+ */
+function getTenureMultiplier(tenureHours) {
+  if (tenureHours >= 720) return 1.5;
+  if (tenureHours >= 336) return 1.4;
+  if (tenureHours >= 168) return 1.3;
+  if (tenureHours >= 72) return 1.2;
+  if (tenureHours >= 24) return 1.1;
+  return 1.0;
+}
+
+/**
+ * Calculate Essence earnings for a single seat
+ *
+ * Formula: floor(BASE_RATE_PER_HOUR * tenureMultiplier * cappedHours)
+ * - Hours since lastClaimedAt, capped at MAX_ACCUMULATION_HOURS
+ * - Tenure multiplier based on total time seated (seatedAt)
+ *
+ * @param {object} seat - Seat record from DB
+ * @param {Date} [now] - Current time (for testing)
+ * @returns {number} Integer Essence earned
+ */
+function calculateSeatEarnings(seat, now) {
+  if (!seat || !seat.lastClaimedAt || !seat.seatedAt) return 0;
+
+  const currentTime = now || new Date();
+  const lastClaimed = new Date(seat.lastClaimedAt);
+  const seatedAt = new Date(seat.seatedAt);
+
+  // Hours since last claim (earning period)
+  const hoursSinceLastClaim = (currentTime - lastClaimed) / (1000 * 60 * 60);
+  const cappedHours = Math.min(hoursSinceLastClaim, MAX_ACCUMULATION_HOURS);
+
+  // Tenure = total time seated (for multiplier bracket)
+  const tenureHours = (currentTime - seatedAt) / (1000 * 60 * 60);
+  const multiplier = getTenureMultiplier(tenureHours);
+
+  return Math.floor(BASE_RATE_PER_HOUR * multiplier * cappedHours);
+}
+
+/**
+ * Check if a totem meets the minimum stage for the Sanctum (Stage 4+ / 3500 XP)
+ * @param {object} totem - Totem record
+ * @returns {boolean}
+ */
+function isSanctumEligible(totem) {
+  return (totem.experience || 0) >= SANCTUM_MIN_XP;
+}
+
+// =============================================================================
+// Service Functions
+// =============================================================================
+
+/**
+ * Get the user's sanctum state including all seats and pending earnings
+ *
+ * @param {string} userId - User ID
+ * @returns {Promise<object>} Sanctum state
+ */
+async function getSanctum(userId) {
+  // Query all seat records for this user
+  const seats = await queryItems(TABLES.EXPEDITION_STATE, 'pk', sanctumPK(userId), {
+    skPrefix: 'SEAT#',
+  });
+
+  // Get user's tier (for max seats calculation)
+  const user = await require('../common/db-client').getUser(userId);
+  const userTier = user?.subscription?.tier || 0;
+
+  // Calculate max seats
+  const maxSeats = await getMaxSeats(userId, userTier);
+
+  const now = new Date();
+
+  // Enrich each seat with totem data and compute earnings
+  const seatData = [];
+  for (const seat of seats) {
+    const totem = await getTotem(userId, seat.totemId);
+    const tenureHours = (now - new Date(seat.seatedAt)) / 3_600_000;
+    const multiplier = getTenureMultiplier(tenureHours);
+    const accumulated = calculateSeatEarnings(seat, now);
+
+    // Check for active mission
+    const missionRecord = await getItem(TABLES.EXPEDITION_STATE, {
+      pk: sanctumPK(userId),
+      sk: missionActiveSK(seat.totemId),
+    });
+
+    seatData.push({
+      seatIndex: seat.seatIndex,
+      totemId: seat.totemId,
+      totemName: totem?.nickname || SPECIES_DISPLAY_NAMES[totem?.speciesId] || 'Totem',
+      species: SPECIES_DISPLAY_NAMES[totem?.speciesId] || `Species ${totem?.speciesId}`,
+      seatedAt: seat.seatedAt,
+      lastClaimedAt: seat.lastClaimedAt,
+      tenureDays: +(tenureHours / 24).toFixed(1),
+      tenureMultiplier: multiplier,
+      accumulatedEssence: accumulated,
+      atCap: (now - new Date(seat.lastClaimedAt)) / 3_600_000 >= MAX_ACCUMULATION_HOURS,
+      onMission: !!(totem?.sanctum?.onMission || missionRecord),
+      activeMission: missionRecord ? {
+        missionType: missionRecord.missionType,
+        name: COUNCIL_MISSIONS[missionRecord.missionType]?.name || missionRecord.missionType,
+        startedAt: missionRecord.startedAt,
+        endsAt: missionRecord.endsAt,
+        canClaim: new Date(missionRecord.endsAt) <= now,
+      } : null,
+    });
+  }
+
+  const totalAccumulated = seatData.reduce((sum, s) => sum + s.accumulatedEssence, 0);
+
+  // Determine locked seats (seats the user hasn't unlocked yet)
+  const lockedSeats = [];
+  for (let i = 0; i < 3; i++) {
+    if (i >= maxSeats) lockedSeats.push(i);
+  }
+
+  return {
+    maxSeats,
+    seats: seatData,
+    totalAccumulated,
+    lockedSeats,
+  };
+}
+
+/**
+ * Determine how many sanctum seats a user has unlocked
+ *
+ * Seat 1: Own any Stage 4 totem
+ * Seat 2: VIP tier 1+ OR 5+ Stage 4 totems
+ * Seat 3: VIP tier 2 OR 10+ Stage 4 totems
+ *
+ * @param {string} userId - User ID
+ * @param {number} userTier - User's subscription tier (0=free, 1=premium, 2=VIP)
+ * @returns {Promise<number>} Number of available seats (0-3)
+ */
+async function getMaxSeats(userId, userTier) {
+  const totems = await getUserTotems(userId);
+  const stage4Count = totems.filter(t => (t.experience || 0) >= SANCTUM_MIN_XP).length;
+
+  if (stage4Count === 0) return 0;
+
+  let seats = 1; // Seat 1: any stage 4 totem
+
+  // Seat 2: VIP tier 1+ OR 5+ stage 4 totems
+  if (userTier >= 1 || stage4Count >= 5) {
+    seats = 2;
+  }
+
+  // Seat 3: VIP tier 2 OR 10+ stage 4 totems
+  if (userTier >= 2 || stage4Count >= 10) {
+    seats = 3;
+  }
+
+  return seats;
+}
+
+/**
+ * Seat a totem in the Elder Sanctum
+ *
+ * @param {string} userId - User ID
+ * @param {string} totemId - Totem to seat
+ * @param {number} [seatIndex] - Specific seat (0, 1, 2). Auto-assigns if omitted.
+ * @returns {Promise<object>} Result with updated sanctum state
+ */
+async function seatTotem(userId, totemId, seatIndex) {
+  // 1. Validate totem exists and is owned
+  const totem = await getTotem(userId, totemId);
+  if (!totem) {
+    return {
+      success: false,
+      error: { code: 'NOT_FOUND', message: 'Totem not found or not owned by you' },
+    };
+  }
+
+  // 2. Must be Stage 4 (Ascended)
+  if (!isSanctumEligible(totem)) {
+    return {
+      success: false,
+      error: {
+        code: 'NOT_ASCENDED',
+        message: 'Totem must be at least Stage 4 (Adult) to enter the Elder Sanctum. Requires 3,500 XP.',
+      },
+    };
+  }
+
+  // 3. Check not already seated
+  if (totem.sanctum && totem.sanctum.seated) {
+    return {
+      success: false,
+      error: {
+        code: 'ALREADY_SEATED',
+        message: 'This totem is already seated in the Elder Sanctum',
+      },
+    };
+  }
+
+  // 4. Check not on expedition
+  const activeExpedition = await getItem(TABLES.EXPEDITION_STATE, {
+    pk: `USER#${userId}`,
+    sk: `EXPEDITION#ACTIVE#${totemId}`,
+  });
+  if (activeExpedition) {
+    return {
+      success: false,
+      error: {
+        code: 'ON_EXPEDITION',
+        message: 'This totem is currently on an expedition and cannot be seated',
+      },
+    };
+  }
+
+  // 5. Get user tier and max seats
+  const user = await require('../common/db-client').getUser(userId);
+  const userTier = user?.subscription?.tier || 0;
+  const maxSeats = await getMaxSeats(userId, userTier);
+
+  if (maxSeats === 0) {
+    return {
+      success: false,
+      error: {
+        code: 'NO_STAGE4_TOTEMS',
+        message: 'You need at least one Stage 4+ totem (3,500 XP) to unlock the Elder Sanctum',
+      },
+    };
+  }
+
+  // 6. Get current seats
+  const existingSeats = await queryItems(TABLES.EXPEDITION_STATE, 'pk', sanctumPK(userId), {
+    skPrefix: 'SEAT#',
+  });
+
+  // Check if totem is already in a seat (double-check via seat records)
+  const alreadySeated = existingSeats.find(s => s.totemId === totemId);
+  if (alreadySeated) {
+    return {
+      success: false,
+      error: {
+        code: 'ALREADY_SEATED',
+        message: 'This totem is already seated in the Elder Sanctum',
+      },
+    };
+  }
+
+  // 7. Determine seat index
+  const occupiedIndices = new Set(existingSeats.map(s => s.seatIndex));
+
+  if (seatIndex !== undefined && seatIndex !== null) {
+    // Validate requested seat
+    if (seatIndex < 0 || seatIndex >= maxSeats) {
+      return {
+        success: false,
+        error: {
+          code: 'NO_AVAILABLE_SEAT',
+          message: `Seat ${seatIndex} is not available. You have ${maxSeats} seat(s) unlocked.`,
+        },
+      };
+    }
+    if (occupiedIndices.has(seatIndex)) {
+      return {
+        success: false,
+        error: {
+          code: 'NO_AVAILABLE_SEAT',
+          message: `Seat ${seatIndex} is already occupied`,
+        },
+      };
+    }
+  }
+  else {
+    // Auto-assign first available seat
+    seatIndex = null;
+    for (let i = 0; i < maxSeats; i++) {
+      if (!occupiedIndices.has(i)) {
+        seatIndex = i;
+        break;
+      }
+    }
+    if (seatIndex === null) {
+      return {
+        success: false,
+        error: {
+          code: 'NO_AVAILABLE_SEAT',
+          message: `All ${maxSeats} seat(s) are occupied. Unseat a totem first.`,
+        },
+      };
+    }
+  }
+
+  // 8. Create seat record
+  const now = new Date().toISOString();
+  const seatRecord = {
+    pk: sanctumPK(userId),
+    sk: seatSK(seatIndex),
+    userId,
+    totemId,
+    totemName: totem.name || totem.species,
+    species: totem.species,
+    rarity: totem.rarity,
+    seatIndex,
+    seatedAt: now,
+    lastClaimedAt: now,
+    onMission: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await putItem(TABLES.EXPEDITION_STATE, seatRecord);
+
+  // 9. Update totem with sanctum field
+  await updateTotem(userId, totemId, {
+    sanctum: {
+      seated: true,
+      seatIndex,
+      seatedAt: now,
+      onMission: false,
+    },
+  });
+
+  // 10. Check sanctum achievements (non-blocking)
+  let achievements = [];
+  try {
+    const totalSeatedCount = existingSeats.length + 1;
+    achievements = await onElderSeated(userId, { totalSeatedCount });
+  }
+  catch (err) {
+    console.error('[Sanctum] Achievement check failed on seatTotem:', err.message);
+  }
+
+  // 11. Return updated sanctum state
+  const sanctum = await getSanctum(userId);
+  return {
+    success: true,
+    data: {
+      ...sanctum,
+      achievements,
+    },
+  };
+}
+
+/**
+ * Remove a totem from the Elder Sanctum
+ *
+ * @param {string} userId - User ID
+ * @param {string} totemId - Totem to unseat
+ * @returns {Promise<object>} Result with updated sanctum state
+ */
+async function unseatTotem(userId, totemId) {
+  // 1. Validate totem exists and is owned
+  const totem = await getTotem(userId, totemId);
+  if (!totem) {
+    return {
+      success: false,
+      error: { code: 'NOT_FOUND', message: 'Totem not found or not owned by you' },
+    };
+  }
+
+  // 2. Check totem is actually seated
+  if (!totem.sanctum || !totem.sanctum.seated) {
+    return {
+      success: false,
+      error: {
+        code: 'NOT_SEATED',
+        message: 'This totem is not seated in the Elder Sanctum',
+      },
+    };
+  }
+
+  // 3. Check not on a council mission
+  if (totem.sanctum.onMission) {
+    return {
+      success: false,
+      error: {
+        code: 'ON_MISSION',
+        message: 'This totem is currently on a council mission and cannot be removed',
+      },
+    };
+  }
+
+  const seatIndex = totem.sanctum.seatIndex;
+
+  // 4. Delete seat record from EXPEDITION_STATE
+  await deleteItem(TABLES.EXPEDITION_STATE, {
+    pk: sanctumPK(userId),
+    sk: seatSK(seatIndex),
+  });
+
+  // 5. Clear sanctum field on totem
+  await updateTotem(userId, totemId, {
+    sanctum: null,
+  });
+
+  // 6. Return updated sanctum state
+  const sanctum = await getSanctum(userId);
+  return {
+    success: true,
+    data: sanctum,
+  };
+}
+
+/**
+ * Claim accumulated Essence from all seated totems (atomic)
+ *
+ * Uses transactWrite for atomic: add Essence + update all lastClaimedAt.
+ * This prevents double-claim race conditions.
+ *
+ * @param {string} userId - User ID
+ * @returns {Promise<object>} Claim result with breakdown per seat
+ */
+async function claimSanctum(userId) {
+  // 1. Query all seats
+  const seats = await queryItems(TABLES.EXPEDITION_STATE, 'pk', sanctumPK(userId), {
+    skPrefix: 'SEAT#',
+  });
+
+  if (seats.length === 0) {
+    return {
+      success: false,
+      error: {
+        code: 'NOTHING_TO_CLAIM',
+        message: 'No totems are seated in the Elder Sanctum',
+      },
+    };
+  }
+
+  // 2. Calculate earnings per seat
+  const now = new Date();
+  const nowISO = now.toISOString();
+  const breakdown = [];
+  let totalEarnings = 0;
+
+  for (const seat of seats) {
+    const earnings = calculateSeatEarnings(seat, now);
+    const tenureHours = (now - new Date(seat.seatedAt)) / (1000 * 60 * 60);
+    breakdown.push({
+      seatIndex: seat.seatIndex,
+      totemId: seat.totemId,
+      totemName: seat.totemName,
+      earnings,
+      tenureMultiplier: getTenureMultiplier(tenureHours),
+      hoursSinceLastClaim: (now - new Date(seat.lastClaimedAt)) / (1000 * 60 * 60),
+    });
+    totalEarnings += earnings;
+  }
+
+  // 3. Must have at least 1 Essence to claim
+  if (totalEarnings < 1) {
+    return {
+      success: false,
+      error: {
+        code: 'NOTHING_TO_CLAIM',
+        message: 'Not enough Essence accumulated yet. Keep your totems seated to earn more.',
+      },
+    };
+  }
+
+  // 4. Atomic transaction: add Essence + update all seat lastClaimedAt
+  const transactItems = [
+    // Add Essence to user
+    {
+      Update: {
+        TableName: TABLES.USERS,
+        Key: { pk: userPK(userId), sk: 'PROFILE' },
+        UpdateExpression: 'SET currencies.essence = if_not_exists(currencies.essence, :zero) + :amount, updatedAt = :now',
+        ConditionExpression: 'attribute_exists(pk)',
+        ExpressionAttributeValues: {
+          ':amount': totalEarnings,
+          ':zero': 0,
+          ':now': nowISO,
+        },
+      },
+    },
+    // Update lastClaimedAt on each seat
+    ...seats.map(seat => ({
+      Update: {
+        TableName: TABLES.EXPEDITION_STATE,
+        Key: { pk: sanctumPK(userId), sk: seatSK(seat.seatIndex) },
+        UpdateExpression: 'SET lastClaimedAt = :now, updatedAt = :now',
+        ExpressionAttributeValues: {
+          ':now': nowISO,
+        },
+      },
+    })),
+  ];
+
+  await transactWrite(transactItems);
+
+  // 5. Get updated balance for response
+  const user = await require('../common/db-client').getUser(userId);
+  const newEssenceBalance = user?.currencies?.essence || 0;
+
+  // 6. Check sanctum claim achievements (non-blocking)
+  let achievements = [];
+  try {
+    // Get current claim count from achievement progress (incremental)
+    const { getAchievementProgress } = require('./achievements-service');
+    const claimProgress = await getAchievementProgress(userId, 'ach_sanctum-claim');
+    const totalClaimCount = (claimProgress?.currentValue || 0) + 1;
+    achievements = await onSanctumClaimed(userId, { totalClaimCount });
+  }
+  catch (err) {
+    console.error('[Sanctum] Achievement check failed on claimSanctum:', err.message);
+  }
+
+  return {
+    success: true,
+    data: {
+      totalClaimed: totalEarnings,
+      newEssenceBalance,
+      breakdown,
+      claimedAt: nowISO,
+      achievements,
+    },
+  };
+}
+
+// =============================================================================
+// Council Mission Constants
+// =============================================================================
+
+const COUNCIL_MISSIONS = {
+  // Governance: Stage 4+ (Adult) — short local leadership tasks. Rewards: XP + Lesser Rune chance
+  'cm_decree-of-wisdom': { id: 'cm_decree-of-wisdom', name: 'Decree of Wisdom', tier: 'governance', requiredStage: 3, duration: 7200, cost: { essence: 10, happiness: 5 }, rewards: { xp: 20, runes: { lesser: 50 } } },
+  'cm_territorial-survey': { id: 'cm_territorial-survey', name: 'Territorial Survey', tier: 'governance', requiredStage: 3, duration: 10800, cost: { essence: 12, happiness: 5 }, rewards: { xp: 30, runes: { lesser: 50 } } },
+  'cm_spirit-audience': { id: 'cm_spirit-audience', name: 'Spirit Audience', tier: 'governance', requiredStage: 3, duration: 14400, cost: { essence: 15, happiness: 8 }, rewards: { xp: 40, runes: { lesser: 50 } } },
+  // Diplomacy: Stage 5 (Ascended) only — longer, higher stakes. Rewards: XP + Greater Rune chance
+  'cm_peace-summit': { id: 'cm_peace-summit', name: 'Peace Summit', tier: 'diplomacy', requiredStage: 4, duration: 21600, cost: { essence: 20, happiness: 10 }, rewards: { xp: 30, runes: { greater: 50 } } },
+  'cm_alliance-forging': { id: 'cm_alliance-forging', name: 'Alliance Forging', tier: 'diplomacy', requiredStage: 4, duration: 28800, cost: { essence: 25, happiness: 12 }, rewards: { xp: 45, runes: { greater: 50 } } },
+  'cm_elder-exchange': { id: 'cm_elder-exchange', name: 'Elder Exchange', tier: 'diplomacy', requiredStage: 4, duration: 28800, cost: { essence: 25, happiness: 12 }, rewards: { xp: 45, runes: { greater: 50 } } },
+  // Legacy: Stage 5 (Ascended) only — epic endgame missions. Rewards: XP + Greater Rune + Ancient Rune chance
+  'cm_rite-of-passage': { id: 'cm_rite-of-passage', name: 'Rite of Passage', tier: 'legacy', requiredStage: 4, duration: 43200, cost: { essence: 30, happiness: 15 }, rewards: { xp: 60, runes: { greater: 75, ancient: 10 } } },
+  'cm_ancient-convocation': { id: 'cm_ancient-convocation', name: 'Ancient Convocation', tier: 'legacy', requiredStage: 4, duration: 64800, cost: { essence: 40, happiness: 18 }, rewards: { xp: 90, runes: { greater: 75, ancient: 15 } } },
+  'cm_founding-ritual': { id: 'cm_founding-ritual', name: 'Founding Ritual', tier: 'legacy', requiredStage: 4, duration: 86400, cost: { essence: 50, happiness: 20 }, rewards: { xp: 120, runes: { greater: 75, ancient: 20 } } },
+};
+
+// =============================================================================
+// Council Mission Key Helpers
+// =============================================================================
+
+function missionActiveSK(totemId) {
+  return `MISSION#ACTIVE#${totemId}`;
+}
+
+// =============================================================================
+// Council Mission Service Functions
+// =============================================================================
+
+/**
+ * Get all council missions grouped by tier
+ *
+ * @returns {object} Missions grouped by tier { governance: [...], diplomacy: [...], legacy: [...] }
+ */
+function getCouncilMissions() {
+  const grouped = { governance: [], diplomacy: [], legacy: [] };
+  for (const mission of Object.values(COUNCIL_MISSIONS)) {
+    grouped[mission.tier].push(mission);
+  }
+  return grouped;
+}
+
+/**
+ * Start a council mission for a seated totem
+ *
+ * @param {string} userId - User ID
+ * @param {string} totemId - Totem ID (must be seated)
+ * @param {string} missionType - Mission ID from COUNCIL_MISSIONS
+ * @returns {Promise<object>} Result with mission info
+ */
+async function startCouncilMission(userId, totemId, missionType) {
+  // 1. Validate mission type
+  const mission = COUNCIL_MISSIONS[missionType];
+  if (!mission) {
+    return {
+      success: false,
+      error: { code: 'INVALID_MISSION', message: `Unknown mission type: ${missionType}` },
+    };
+  }
+
+  // 2. Get totem — must be owned by user
+  const totem = await getTotem(userId, totemId);
+  if (!totem) {
+    return {
+      success: false,
+      error: { code: 'NOT_FOUND', message: 'Totem not found or not owned by you' },
+    };
+  }
+
+  // 3. Totem must be seated
+  if (!totem.sanctum || !totem.sanctum.seated) {
+    return {
+      success: false,
+      error: { code: 'NOT_SEATED', message: 'Totem must be seated in the Elder Sanctum to start a council mission' },
+    };
+  }
+
+  // 4. Totem must meet the mission's stage requirement
+  const totemStage = totem.stage || 0;
+  if (totemStage < mission.requiredStage) {
+    const tierLabel = mission.tier === 'governance' ? 'Stage 4 (Adult)' : 'Stage 5 (Ascended)';
+    return {
+      success: false,
+      error: { code: 'INSUFFICIENT_STAGE', message: `${mission.tier.charAt(0).toUpperCase() + mission.tier.slice(1)} missions require ${tierLabel} totems` },
+    };
+  }
+
+  // 5. Totem must NOT already be on a mission
+  const existingMission = await getItem(TABLES.EXPEDITION_STATE, {
+    pk: sanctumPK(userId),
+    sk: missionActiveSK(totemId),
+  });
+  if (existingMission) {
+    return {
+      success: false,
+      error: { code: 'ALREADY_ON_MISSION', message: 'This totem is already on a council mission' },
+    };
+  }
+
+  // 5. User must have enough Essence
+  const user = await require('../common/db-client').getUser(userId);
+  const currentEssence = user?.currencies?.essence || 0;
+  if (currentEssence < mission.cost.essence) {
+    return {
+      success: false,
+      error: { code: 'INSUFFICIENT_ESSENCE', message: `Need ${mission.cost.essence} Essence, have ${currentEssence}` },
+    };
+  }
+
+  // 6. Totem must have enough happiness
+  const currentHappiness = totem.stats?.happiness ?? totem.happiness ?? 0;
+  if (currentHappiness < mission.cost.happiness) {
+    return {
+      success: false,
+      error: { code: 'INSUFFICIENT_HAPPINESS', message: `Need ${mission.cost.happiness} happiness, have ${currentHappiness}` },
+    };
+  }
+
+  // 7. Deduct Essence from user
+  const deductResult = await require('../common/db-client').deductEssence(userId, mission.cost.essence, {
+    type: 'council_mission',
+    ref: missionType,
+  });
+  if (!deductResult.success) {
+    return {
+      success: false,
+      error: { code: 'INSUFFICIENT_ESSENCE', message: deductResult.error || 'Failed to deduct Essence' },
+    };
+  }
+
+  // 8. Deduct happiness from totem
+  const newHappiness = currentHappiness - mission.cost.happiness;
+  await updateTotem(userId, totemId, {
+    'stats.happiness': newHappiness,
+  });
+
+  // 9. Create mission record
+  const now = Date.now();
+  const nowISO = new Date(now).toISOString();
+  const endsAt = now + mission.duration * 1000;
+  const endsAtISO = new Date(endsAt).toISOString();
+  const seatIndex = totem.sanctum.seatIndex;
+
+  const missionRecord = {
+    pk: sanctumPK(userId),
+    sk: missionActiveSK(totemId),
+    totemId,
+    seatIndex,
+    missionType,
+    startedAt: nowISO,
+    endsAt: endsAtISO,
+    status: 'in_progress',
+    claimed: false,
+    createdAt: nowISO,
+    updatedAt: nowISO,
+  };
+
+  await putItem(TABLES.EXPEDITION_STATE, missionRecord);
+
+  // 10. Update totem sanctum field
+  await updateTotem(userId, totemId, {
+    sanctum: {
+      ...totem.sanctum,
+      onMission: true,
+      missionEndsAt: endsAtISO,
+    },
+  });
+
+  return {
+    success: true,
+    data: {
+      mission: {
+        missionType,
+        name: mission.name,
+        tier: mission.tier,
+        totemId,
+        seatIndex,
+        startedAt: nowISO,
+        endsAt: endsAtISO,
+        duration: mission.duration,
+        rewards: mission.rewards,
+      },
+      newEssenceBalance: deductResult.newBalance,
+    },
+  };
+}
+
+/**
+ * Claim rewards from a completed council mission
+ *
+ * @param {string} userId - User ID
+ * @param {string} totemId - Totem ID
+ * @returns {Promise<object>} Claim result with rewards
+ */
+async function claimCouncilMission(userId, totemId) {
+  // 1. Get active mission record
+  const missionRecord = await getItem(TABLES.EXPEDITION_STATE, {
+    pk: sanctumPK(userId),
+    sk: missionActiveSK(totemId),
+  });
+
+  if (!missionRecord) {
+    return {
+      success: false,
+      error: { code: 'MISSION_NOT_FOUND', message: 'No active council mission found for this totem' },
+    };
+  }
+
+  // 2. Verify mission is complete
+  const now = Date.now();
+  const endsAt = new Date(missionRecord.endsAt).getTime();
+  if (endsAt > now) {
+    return {
+      success: false,
+      error: { code: 'MISSION_NOT_COMPLETE', message: 'Council mission is not yet complete' },
+    };
+  }
+
+  const mission = COUNCIL_MISSIONS[missionRecord.missionType];
+  if (!mission) {
+    return {
+      success: false,
+      error: { code: 'INVALID_MISSION', message: 'Mission definition not found' },
+    };
+  }
+
+  // 3. Award XP to totem
+  const totem = await getTotem(userId, totemId);
+  const currentXP = totem?.experience || 0;
+  await updateTotem(userId, totemId, {
+    experience: currentXP + mission.rewards.xp,
+  });
+
+  // 4. Roll for rune drops based on mission tier chances
+  const runesEarned = { lesser: 0, greater: 0, ancient: 0 };
+  if (mission.rewards.runes) {
+    for (const [runeType, chance] of Object.entries(mission.rewards.runes)) {
+      if (Math.random() * 100 < chance) {
+        runesEarned[runeType] = 1;
+      }
+    }
+  }
+
+  // Award runes if any dropped
+  let newRuneBalances = null;
+  if (runesEarned.lesser || runesEarned.greater || runesEarned.ancient) {
+    newRuneBalances = await addRunes(userId, runesEarned, {
+      type: 'council_mission_claim',
+      ref: mission.id,
+    });
+  }
+
+  // 5. Log transaction for mission claim
+  await logTransaction(userId, {
+    type: 'council_mission_claim',
+    currency: 'xp',
+    amount: mission.rewards.xp,
+    ref: missionRecord.missionType,
+    refType: 'council_mission',
+    refName: mission.name,
+  });
+
+  // 6. Delete mission record
+  await deleteItem(TABLES.EXPEDITION_STATE, {
+    pk: sanctumPK(userId),
+    sk: missionActiveSK(totemId),
+  });
+
+  // 7. Update totem: clear onMission flag + missionEndsAt
+  await updateTotem(userId, totemId, {
+    sanctum: {
+      ...(totem?.sanctum || {}),
+      onMission: false,
+      missionEndsAt: null,
+    },
+  });
+
+  // 8. Check council mission achievements (non-blocking)
+  let achievements = [];
+  try {
+    const { getAchievementProgress } = require('./achievements-service');
+    const missionProgress = await getAchievementProgress(userId, 'ach_council-missions');
+    const totalMissionCount = (missionProgress?.currentValue || 0) + 1;
+    achievements = await onMissionCompleted(userId, {
+      missionType: missionRecord.missionType,
+      totalMissionCount,
+    });
+  }
+  catch (err) {
+    console.error('[Sanctum] Achievement check failed on claimCouncilMission:', err.message);
+  }
+
+  return {
+    success: true,
+    data: {
+      rewards: {
+        xp: mission.rewards.xp,
+        runesEarned,
+      },
+      missionType: missionRecord.missionType,
+      missionName: mission.name,
+      totemId,
+      newRuneBalances,
+      achievements,
+    },
+  };
+}
+
+/**
+ * Cancel an active council mission (no refund, no rewards)
+ *
+ * @param {string} userId - User ID
+ * @param {string} totemId - Totem ID
+ * @returns {Promise<object>} Success result
+ */
+async function cancelCouncilMission(userId, totemId) {
+  // 1. Get active mission record
+  const missionRecord = await getItem(TABLES.EXPEDITION_STATE, {
+    pk: sanctumPK(userId),
+    sk: missionActiveSK(totemId),
+  });
+
+  if (!missionRecord) {
+    return {
+      success: false,
+      error: { code: 'MISSION_NOT_FOUND', message: 'No active council mission found for this totem' },
+    };
+  }
+
+  // 2. Delete mission record (no rewards)
+  await deleteItem(TABLES.EXPEDITION_STATE, {
+    pk: sanctumPK(userId),
+    sk: missionActiveSK(totemId),
+  });
+
+  // 3. Update totem: clear onMission flag + missionEndsAt
+  const totem = await getTotem(userId, totemId);
+  if (totem) {
+    await updateTotem(userId, totemId, {
+      sanctum: {
+        ...(totem.sanctum || {}),
+        onMission: false,
+        missionEndsAt: null,
+      },
+    });
+  }
+
+  return {
+    success: true,
+    data: {
+      cancelled: true,
+      missionType: missionRecord.missionType,
+      totemId,
+    },
+  };
+}
+
+// =============================================================================
+// Exports
+// =============================================================================
+
+module.exports = {
+  // Service functions
+  getSanctum,
+  seatTotem,
+  unseatTotem,
+  claimSanctum,
+  getMaxSeats,
+
+  // Council Mission functions
+  getCouncilMissions,
+  startCouncilMission,
+  claimCouncilMission,
+  cancelCouncilMission,
+
+  // Helpers (exported for testing)
+  getTenureMultiplier,
+  calculateSeatEarnings,
+  isSanctumEligible,
+
+  // Constants (exported for testing)
+  SANCTUM_MIN_XP,
+  MAX_ACCUMULATION_HOURS,
+  BASE_RATE_PER_HOUR,
+  MAX_SEATS,
+  COUNCIL_MISSIONS,
+
+  // Key helpers (for external use)
+  sanctumPK,
+  seatSK,
+  missionActiveSK,
+};

--- a/test/achievements-service.test.js
+++ b/test/achievements-service.test.js
@@ -77,8 +77,8 @@ describe('Achievements Service', () => {
   // =============================================================================
 
   describe('Achievement Constants', () => {
-    it('should define 19 achievement IDs', () => {
-      expect(Object.keys(ACHIEVEMENT_IDS)).toHaveLength(19);
+    it('should define 25 achievement IDs', () => {
+      expect(Object.keys(ACHIEVEMENT_IDS)).toHaveLength(25);
     });
 
     it('should have all achievement IDs prefixed with ach_', () => {
@@ -87,8 +87,8 @@ describe('Achievements Service', () => {
       });
     });
 
-    it('should define 8 one-time achievements', () => {
-      expect(ONETIME_ACHIEVEMENTS).toHaveLength(8);
+    it('should define 10 one-time achievements', () => {
+      expect(ONETIME_ACHIEVEMENTS).toHaveLength(10);
       expect(ONETIME_ACHIEVEMENTS).toContain(ACHIEVEMENT_IDS.RARE_COLLECTOR);
       expect(ONETIME_ACHIEVEMENTS).toContain(ACHIEVEMENT_IDS.EPIC_COLLECTOR);
       expect(ONETIME_ACHIEVEMENTS).toContain(ACHIEVEMENT_IDS.LEGENDARY_COLLECTOR);
@@ -96,8 +96,8 @@ describe('Achievements Service', () => {
       expect(ONETIME_ACHIEVEMENTS).toContain(ACHIEVEMENT_IDS.EXPEDITION_EXPLORER);
     });
 
-    it('should define milestone thresholds for 11 progression achievements', () => {
-      expect(Object.keys(ACHIEVEMENT_MILESTONES)).toHaveLength(11);
+    it('should define milestone thresholds for 15 progression achievements', () => {
+      expect(Object.keys(ACHIEVEMENT_MILESTONES)).toHaveLength(15);
     });
 
     it('should have ascending milestone thresholds', () => {

--- a/test/sanctum-handlers.test.js
+++ b/test/sanctum-handlers.test.js
@@ -1,0 +1,169 @@
+/**
+ * Sanctum Handler Validation Tests
+ *
+ * Tests param validation in the thin handler layer (functions/sanctum/).
+ * Service-level logic is tested in sanctum.test.js.
+ */
+
+const { seatTotem } = require('../src/functions/sanctum/seat');
+const { unseatTotem } = require('../src/functions/sanctum/unseat');
+const { startCouncilMission } = require('../src/functions/sanctum/mission-start');
+const { claimCouncilMission } = require('../src/functions/sanctum/mission-claim');
+const { cancelCouncilMission } = require('../src/functions/sanctum/mission-cancel');
+
+// Mock the service — we only test handler validation here
+jest.mock('../src/services/sanctum-service', () => ({
+  seatTotem: jest.fn(),
+  unseatTotem: jest.fn(),
+  startCouncilMission: jest.fn(),
+  claimCouncilMission: jest.fn(),
+  cancelCouncilMission: jest.fn(),
+}));
+
+const user = { userId: 'usr_test123' };
+
+describe('Sanctum Handler Validation', () => {
+  describe('seatTotem', () => {
+    it('should reject missing totemId', async () => {
+      const result = await seatTotem(user, {});
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSING_PARAM');
+    });
+
+    it('should reject null body', async () => {
+      const result = await seatTotem(user, null);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSING_PARAM');
+    });
+
+    it('should reject invalid totemId format', async () => {
+      const result = await seatTotem(user, { totemId: 'bad_id' });
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INVALID_ID');
+    });
+
+    it('should reject invalid seatIndex (negative)', async () => {
+      const result = await seatTotem(user, { totemId: 'ttm_abc', seatIndex: -1 });
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INVALID_PARAM');
+    });
+
+    it('should reject invalid seatIndex (> 2)', async () => {
+      const result = await seatTotem(user, { totemId: 'ttm_abc', seatIndex: 3 });
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INVALID_PARAM');
+    });
+
+    it('should reject non-integer seatIndex', async () => {
+      const result = await seatTotem(user, { totemId: 'ttm_abc', seatIndex: 1.5 });
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INVALID_PARAM');
+    });
+
+    it('should pass valid params to service', async () => {
+      const sanctumService = require('../src/services/sanctum-service');
+      sanctumService.seatTotem.mockResolvedValue({ success: true });
+
+      const result = await seatTotem(user, { totemId: 'ttm_abc', seatIndex: 1 });
+      expect(result.success).toBe(true);
+      expect(sanctumService.seatTotem).toHaveBeenCalledWith('usr_test123', 'ttm_abc', 1);
+    });
+
+    it('should allow omitted seatIndex', async () => {
+      const sanctumService = require('../src/services/sanctum-service');
+      sanctumService.seatTotem.mockResolvedValue({ success: true });
+
+      const result = await seatTotem(user, { totemId: 'ttm_abc' });
+      expect(result.success).toBe(true);
+      expect(sanctumService.seatTotem).toHaveBeenCalledWith('usr_test123', 'ttm_abc', undefined);
+    });
+  });
+
+  describe('unseatTotem', () => {
+    it('should reject missing totemId', async () => {
+      const result = await unseatTotem(user, {});
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSING_PARAM');
+    });
+
+    it('should reject invalid totemId format', async () => {
+      const result = await unseatTotem(user, { totemId: 'totem_123' });
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INVALID_ID');
+    });
+
+    it('should pass valid params to service', async () => {
+      const sanctumService = require('../src/services/sanctum-service');
+      sanctumService.unseatTotem.mockResolvedValue({ success: true });
+
+      const result = await unseatTotem(user, { totemId: 'ttm_xyz' });
+      expect(result.success).toBe(true);
+      expect(sanctumService.unseatTotem).toHaveBeenCalledWith('usr_test123', 'ttm_xyz');
+    });
+  });
+
+  describe('startCouncilMission', () => {
+    it('should reject missing totemId', async () => {
+      const result = await startCouncilMission(user, { missionType: 'cm_decree-of-wisdom' });
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSING_PARAM');
+      expect(result.error.message).toMatch(/totemId/);
+    });
+
+    it('should reject missing missionType', async () => {
+      const result = await startCouncilMission(user, { totemId: 'ttm_abc' });
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSING_PARAM');
+      expect(result.error.message).toMatch(/missionType/);
+    });
+
+    it('should reject empty body', async () => {
+      const result = await startCouncilMission(user, null);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSING_PARAM');
+    });
+
+    it('should pass valid params to service', async () => {
+      const sanctumService = require('../src/services/sanctum-service');
+      sanctumService.startCouncilMission.mockResolvedValue({ success: true });
+
+      const result = await startCouncilMission(user, { totemId: 'ttm_abc', missionType: 'cm_decree-of-wisdom' });
+      expect(result.success).toBe(true);
+      expect(sanctumService.startCouncilMission).toHaveBeenCalledWith('usr_test123', 'ttm_abc', 'cm_decree-of-wisdom');
+    });
+  });
+
+  describe('claimCouncilMission', () => {
+    it('should reject missing totemId', async () => {
+      const result = await claimCouncilMission(user, {});
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSING_PARAM');
+    });
+
+    it('should pass valid params to service', async () => {
+      const sanctumService = require('../src/services/sanctum-service');
+      sanctumService.claimCouncilMission.mockResolvedValue({ success: true });
+
+      const result = await claimCouncilMission(user, { totemId: 'ttm_abc' });
+      expect(result.success).toBe(true);
+      expect(sanctumService.claimCouncilMission).toHaveBeenCalledWith('usr_test123', 'ttm_abc');
+    });
+  });
+
+  describe('cancelCouncilMission', () => {
+    it('should reject missing totemId', async () => {
+      const result = await cancelCouncilMission(user, {});
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSING_PARAM');
+    });
+
+    it('should pass valid params to service', async () => {
+      const sanctumService = require('../src/services/sanctum-service');
+      sanctumService.cancelCouncilMission.mockResolvedValue({ success: true });
+
+      const result = await cancelCouncilMission(user, { totemId: 'ttm_abc' });
+      expect(result.success).toBe(true);
+      expect(sanctumService.cancelCouncilMission).toHaveBeenCalledWith('usr_test123', 'ttm_abc');
+    });
+  });
+});

--- a/test/sanctum.test.js
+++ b/test/sanctum.test.js
@@ -1,0 +1,929 @@
+/**
+ * Sanctum Service Tests
+ *
+ * Tests for the Elder Sanctum feature including seat management,
+ * passive earnings, and council missions.
+ */
+
+// Mock the db-client before requiring the service
+jest.mock('../src/common/db-client', () => ({
+  getItem: jest.fn(),
+  putItem: jest.fn(),
+  deleteItem: jest.fn(),
+  queryItems: jest.fn(),
+  getTotem: jest.fn(),
+  updateTotem: jest.fn(),
+  addEssence: jest.fn(),
+  addRunes: jest.fn(),
+  deductEssence: jest.fn(),
+  getUserTotems: jest.fn(),
+  getUser: jest.fn(),
+  transactWrite: jest.fn(),
+  logTransaction: jest.fn(),
+  userPK: jest.fn((userId) => `USER#${userId}`),
+  TABLES: {
+    USERS: 'TotemBound-Users',
+    TOTEMS: 'TotemBound-Totems',
+    EXPEDITION_STATE: 'TotemBound-ExpeditionState',
+    TRANSACTIONS: 'TotemBound-Transactions',
+  },
+}));
+
+const sanctumService = require('../src/services/sanctum-service');
+const dbClient = require('../src/common/db-client');
+
+describe('Sanctum Service', () => {
+  const testUserId = 'usr_test123';
+  const testTotemId = 'ttm_test456';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  // ===========================================================================
+  // getTenureMultiplier
+  // ===========================================================================
+
+  describe('getTenureMultiplier', () => {
+    it('should return 1.0 for 0 hours', () => {
+      expect(sanctumService.getTenureMultiplier(0)).toBe(1.0);
+    });
+
+    it('should return 1.0 for 23 hours (under 24hr threshold)', () => {
+      expect(sanctumService.getTenureMultiplier(23)).toBe(1.0);
+    });
+
+    it('should return 1.1 at exactly 24 hours', () => {
+      expect(sanctumService.getTenureMultiplier(24)).toBe(1.1);
+    });
+
+    it('should return 1.2 at exactly 72 hours', () => {
+      expect(sanctumService.getTenureMultiplier(72)).toBe(1.2);
+    });
+
+    it('should return 1.3 at exactly 168 hours', () => {
+      expect(sanctumService.getTenureMultiplier(168)).toBe(1.3);
+    });
+
+    it('should return 1.5 at 720+ hours', () => {
+      expect(sanctumService.getTenureMultiplier(720)).toBe(1.5);
+      expect(sanctumService.getTenureMultiplier(1000)).toBe(1.5);
+    });
+  });
+
+  // ===========================================================================
+  // calculateSeatEarnings
+  // ===========================================================================
+
+  describe('calculateSeatEarnings', () => {
+    it('should return 0 for a just-seated totem (no time elapsed)', () => {
+      const now = new Date('2026-03-28T12:00:00Z');
+      const seat = {
+        seatedAt: now.toISOString(),
+        lastClaimedAt: now.toISOString(),
+      };
+      expect(sanctumService.calculateSeatEarnings(seat, now)).toBe(0);
+    });
+
+    it('should calculate correct earnings at 36hr with 1.2x multiplier', () => {
+      // 36 hours since claim, tenure 72+ hours => 1.2x
+      const seatedAt = new Date('2026-03-24T00:00:00Z'); // seated 4 days ago (96 hrs)
+      const lastClaimed = new Date('2026-03-27T00:00:00Z'); // claimed 36 hrs ago
+      const now = new Date('2026-03-28T12:00:00Z');
+
+      const seat = {
+        seatedAt: seatedAt.toISOString(),
+        lastClaimedAt: lastClaimed.toISOString(),
+      };
+
+      // tenureHours = 108 => 1.2x multiplier
+      // hoursSinceLastClaim = 36, capped at 36 (under 168)
+      // floor(0.5 * 1.2 * 36) = floor(21.6) = 21
+      expect(sanctumService.calculateSeatEarnings(seat, now)).toBe(21);
+    });
+
+    it('should cap accumulation at 168 hours', () => {
+      const seatedAt = new Date('2026-03-01T00:00:00Z'); // seated long ago (648 hrs)
+      const lastClaimed = new Date('2026-03-01T00:00:00Z'); // never re-claimed
+      const now = new Date('2026-03-28T00:00:00Z'); // 648 hours later
+
+      const seat = {
+        seatedAt: seatedAt.toISOString(),
+        lastClaimedAt: lastClaimed.toISOString(),
+      };
+
+      // tenureHours = 648 => 1.4x (>=336, <720)
+      // hoursSinceLastClaim = 648, capped at 168
+      // floor(0.5 * 1.4 * 168) = floor(117.6) = 117
+      expect(sanctumService.calculateSeatEarnings(seat, now)).toBe(117);
+    });
+
+    it('should floor the result to an integer', () => {
+      // 10 hours since claim, tenure < 24hrs => 1.0x
+      const now = new Date('2026-03-28T10:00:00Z');
+      const seatedAt = new Date('2026-03-28T00:00:00Z');
+      const lastClaimed = new Date('2026-03-28T00:00:00Z');
+
+      const seat = {
+        seatedAt: seatedAt.toISOString(),
+        lastClaimedAt: lastClaimed.toISOString(),
+      };
+
+      // floor(0.5 * 1.0 * 10) = floor(5.0) = 5
+      expect(sanctumService.calculateSeatEarnings(seat, now)).toBe(5);
+    });
+  });
+
+  // ===========================================================================
+  // seatTotem - validation
+  // ===========================================================================
+
+  describe('seatTotem - validation', () => {
+    it('should reject when totem is not found', async () => {
+      dbClient.getTotem.mockResolvedValue(null);
+
+      const result = await sanctumService.seatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+
+    it('should reject when totem is below Stage 4 (under 3500 XP)', async () => {
+      dbClient.getTotem.mockResolvedValue({ experience: 2000, species: 'fox' });
+
+      const result = await sanctumService.seatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_ASCENDED');
+    });
+
+    it('should reject when totem is already seated', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        sanctum: { seated: true, seatIndex: 0 },
+      });
+
+      const result = await sanctumService.seatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('ALREADY_SEATED');
+    });
+
+    it('should reject when totem is on an expedition', async () => {
+      dbClient.getTotem.mockResolvedValue({ experience: 8000, species: 'fox' });
+      dbClient.getItem.mockResolvedValue({ pk: 'USER#usr_test123', sk: `EXPEDITION#ACTIVE#${testTotemId}` });
+
+      const result = await sanctumService.seatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('ON_EXPEDITION');
+    });
+
+    it('should reject when user has no Stage 4 totems (maxSeats=0)', async () => {
+      dbClient.getTotem.mockResolvedValue({ experience: 8000, species: 'fox' });
+      dbClient.getItem.mockResolvedValue(null); // no expedition
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+      dbClient.getUserTotems.mockResolvedValue([]); // no totems at all
+
+      const result = await sanctumService.seatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NO_STAGE4_TOTEMS');
+    });
+
+    it('should reject when all seats are occupied', async () => {
+      dbClient.getTotem.mockResolvedValue({ experience: 8000, species: 'fox' });
+      dbClient.getItem.mockResolvedValue(null); // no expedition
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+      // Only 1 stage4 totem => maxSeats = 1
+      dbClient.getUserTotems.mockResolvedValue([{ experience: 8000 }]);
+      // Seat 0 already occupied by a different totem
+      dbClient.queryItems.mockResolvedValue([{ seatIndex: 0, totemId: 'ttm_other' }]);
+
+      const result = await sanctumService.seatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NO_AVAILABLE_SEAT');
+    });
+  });
+
+  // ===========================================================================
+  // seatTotem - success
+  // ===========================================================================
+
+  describe('seatTotem - success', () => {
+    it('should seat a totem successfully and return sanctum state', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        name: 'Foxy',
+        rarity: 'Rare',
+      });
+      dbClient.getItem.mockResolvedValue(null); // no expedition
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 }, subscription: { tier: 0 } });
+      dbClient.getUserTotems.mockResolvedValue([{ experience: 8000 }]); // 1 stage4 => 1 seat
+      dbClient.queryItems
+        .mockResolvedValueOnce([]) // no existing seats (for seatTotem)
+        .mockResolvedValueOnce([]); // getSanctum query after seat
+      dbClient.putItem.mockResolvedValue({});
+      dbClient.updateTotem.mockResolvedValue({});
+
+      const result = await sanctumService.seatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(true);
+      expect(dbClient.putItem).toHaveBeenCalledWith(
+        'TotemBound-ExpeditionState',
+        expect.objectContaining({
+          pk: `SANCTUM#${testUserId}`,
+          sk: 'SEAT#0',
+          totemId: testTotemId,
+          seatIndex: 0,
+          onMission: false,
+        }),
+      );
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        expect.objectContaining({
+          sanctum: expect.objectContaining({
+            seated: true,
+            seatIndex: 0,
+            onMission: false,
+          }),
+        }),
+      );
+    });
+
+    it('should auto-assign to seat index 1 when seat 0 is taken', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        name: 'Foxy',
+        rarity: 'Rare',
+      });
+      dbClient.getItem.mockResolvedValue(null);
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 }, subscription: { tier: 1 } });
+      // 3 stage4 totems + tier 1 => 2 seats
+      dbClient.getUserTotems.mockResolvedValue([
+        { experience: 8000 },
+        { experience: 9000 },
+        { experience: 10000 },
+      ]);
+      dbClient.queryItems
+        .mockResolvedValueOnce([{ seatIndex: 0, totemId: 'ttm_other' }]) // seat 0 occupied
+        .mockResolvedValueOnce([]); // getSanctum query
+      dbClient.putItem.mockResolvedValue({});
+      dbClient.updateTotem.mockResolvedValue({});
+
+      const result = await sanctumService.seatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(true);
+      expect(dbClient.putItem).toHaveBeenCalledWith(
+        'TotemBound-ExpeditionState',
+        expect.objectContaining({
+          sk: 'SEAT#1',
+          seatIndex: 1,
+        }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // unseatTotem
+  // ===========================================================================
+
+  describe('unseatTotem', () => {
+    it('should reject when totem is not seated', async () => {
+      dbClient.getTotem.mockResolvedValue({ experience: 8000, species: 'fox' });
+
+      const result = await sanctumService.unseatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_SEATED');
+    });
+
+    it('should reject when totem is on a council mission', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        sanctum: { seated: true, seatIndex: 0, onMission: true },
+      });
+
+      const result = await sanctumService.unseatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('ON_MISSION');
+    });
+
+    it('should unseat successfully and clear sanctum field', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        sanctum: { seated: true, seatIndex: 1, onMission: false },
+      });
+      dbClient.deleteItem.mockResolvedValue({});
+      dbClient.updateTotem.mockResolvedValue({});
+      dbClient.queryItems.mockResolvedValue([]); // getSanctum returns empty after unseat
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+      dbClient.getUserTotems.mockResolvedValue([{ experience: 8000 }]);
+
+      const result = await sanctumService.unseatTotem(testUserId, testTotemId);
+      expect(result.success).toBe(true);
+      expect(dbClient.deleteItem).toHaveBeenCalledWith(
+        'TotemBound-ExpeditionState',
+        { pk: `SANCTUM#${testUserId}`, sk: 'SEAT#1' },
+      );
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        { sanctum: null },
+      );
+    });
+
+    it('should clear sanctum field on totem when unseating', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        sanctum: { seated: true, seatIndex: 2, onMission: false },
+      });
+      dbClient.deleteItem.mockResolvedValue({});
+      dbClient.updateTotem.mockResolvedValue({});
+      dbClient.queryItems.mockResolvedValue([]);
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+      dbClient.getUserTotems.mockResolvedValue([{ experience: 8000 }]);
+
+      await sanctumService.unseatTotem(testUserId, testTotemId);
+
+      // Verify updateTotem is called with { sanctum: null } to fully clear the field
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        { sanctum: null },
+      );
+    });
+  });
+
+  // ===========================================================================
+  // claimSanctum
+  // ===========================================================================
+
+  describe('claimSanctum', () => {
+    it('should reject when no seats exist', async () => {
+      dbClient.queryItems.mockResolvedValue([]);
+
+      const result = await sanctumService.claimSanctum(testUserId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOTHING_TO_CLAIM');
+    });
+
+    it('should reject when earnings are less than 1 Essence', async () => {
+      const now = new Date();
+      // Just seated 1 minute ago => earnings = floor(0.5 * 1.0 * (1/60)) = 0
+      dbClient.queryItems.mockResolvedValue([{
+        seatIndex: 0,
+        totemId: testTotemId,
+        totemName: 'Foxy',
+        seatedAt: now.toISOString(),
+        lastClaimedAt: now.toISOString(),
+      }]);
+
+      const result = await sanctumService.claimSanctum(testUserId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOTHING_TO_CLAIM');
+    });
+
+    it('should compute correct amounts and use transactWrite', async () => {
+      const seatedAt = new Date('2026-03-20T00:00:00Z');
+      const lastClaimed = new Date('2026-03-27T00:00:00Z');
+
+      dbClient.queryItems.mockResolvedValue([{
+        seatIndex: 0,
+        totemId: testTotemId,
+        totemName: 'Foxy',
+        seatedAt: seatedAt.toISOString(),
+        lastClaimedAt: lastClaimed.toISOString(),
+      }]);
+      dbClient.transactWrite.mockResolvedValue({});
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 500 } });
+
+      const result = await sanctumService.claimSanctum(testUserId);
+      expect(result.success).toBe(true);
+      expect(result.data.totalClaimed).toBeGreaterThanOrEqual(1);
+      expect(dbClient.transactWrite).toHaveBeenCalledTimes(1);
+
+      // Verify transactWrite includes user Essence update + seat lastClaimedAt update
+      const transactItems = dbClient.transactWrite.mock.calls[0][0];
+      expect(transactItems).toHaveLength(2); // 1 user update + 1 seat update
+      expect(transactItems[0].Update.TableName).toBe('TotemBound-Users');
+      expect(transactItems[1].Update.TableName).toBe('TotemBound-ExpeditionState');
+    });
+
+    it('should update all lastClaimedAt for multiple seats', async () => {
+      const seatedAt = new Date('2026-03-20T00:00:00Z');
+      const lastClaimed = new Date('2026-03-27T00:00:00Z');
+
+      dbClient.queryItems.mockResolvedValue([
+        {
+          seatIndex: 0,
+          totemId: 'ttm_a',
+          totemName: 'Alpha',
+          seatedAt: seatedAt.toISOString(),
+          lastClaimedAt: lastClaimed.toISOString(),
+        },
+        {
+          seatIndex: 1,
+          totemId: 'ttm_b',
+          totemName: 'Beta',
+          seatedAt: seatedAt.toISOString(),
+          lastClaimedAt: lastClaimed.toISOString(),
+        },
+      ]);
+      dbClient.transactWrite.mockResolvedValue({});
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 500 } });
+
+      const result = await sanctumService.claimSanctum(testUserId);
+      expect(result.success).toBe(true);
+
+      // 1 user update + 2 seat updates = 3 items
+      const transactItems = dbClient.transactWrite.mock.calls[0][0];
+      expect(transactItems).toHaveLength(3);
+    });
+  });
+
+  // ===========================================================================
+  // startCouncilMission - validation
+  // ===========================================================================
+
+  describe('startCouncilMission - validation', () => {
+    it('should reject invalid mission type', async () => {
+      const result = await sanctumService.startCouncilMission(testUserId, testTotemId, 'cm_nonexistent');
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INVALID_MISSION');
+    });
+
+    it('should reject when totem is not seated', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        happiness: 50,
+      });
+
+      const result = await sanctumService.startCouncilMission(testUserId, testTotemId, 'cm_decree-of-wisdom');
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_SEATED');
+    });
+
+    it('should reject when totem stage is too low for diplomacy/legacy missions', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 5000,
+        stage: 3, // Adult (UI Stage 4) — not Ascended
+        species: 'fox',
+        happiness: 50,
+        sanctum: { seated: true, seatIndex: 0, onMission: false },
+      });
+
+      const result = await sanctumService.startCouncilMission(testUserId, testTotemId, 'cm_peace-summit');
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INSUFFICIENT_STAGE');
+    });
+
+    it('should allow governance missions for Stage 4 (Adult) totems', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 5000,
+        stage: 3, // Adult (UI Stage 4)
+        species: 'fox',
+        stats: { happiness: 50 },
+        sanctum: { seated: true, seatIndex: 0, onMission: false },
+      });
+      dbClient.getItem.mockResolvedValue(null); // no active mission
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+      dbClient.deductEssence.mockResolvedValue({ success: true, newBalance: 990 });
+      dbClient.putItem.mockResolvedValue();
+      dbClient.updateTotem.mockResolvedValue();
+
+      const result = await sanctumService.startCouncilMission(testUserId, testTotemId, 'cm_decree-of-wisdom');
+      // Should NOT fail with INSUFFICIENT_STAGE — governance only needs stage 3
+      expect(result.error?.code).not.toBe('INSUFFICIENT_STAGE');
+    });
+
+    it('should reject when totem is already on a mission', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        stage: 4,
+        species: 'fox',
+        happiness: 50,
+        sanctum: { seated: true, seatIndex: 0, onMission: false },
+      });
+      dbClient.getItem.mockResolvedValue({
+        pk: `SANCTUM#${testUserId}`,
+        sk: `MISSION#ACTIVE#${testTotemId}`,
+        status: 'in_progress',
+      });
+
+      const result = await sanctumService.startCouncilMission(testUserId, testTotemId, 'cm_decree-of-wisdom');
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('ALREADY_ON_MISSION');
+    });
+
+    it('should reject when user has insufficient Essence', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        stage: 4,
+        species: 'fox',
+        happiness: 50,
+        sanctum: { seated: true, seatIndex: 0, onMission: false },
+      });
+      dbClient.getItem.mockResolvedValue(null); // no active mission
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 5 } }); // only 5, need 15
+
+      const result = await sanctumService.startCouncilMission(testUserId, testTotemId, 'cm_decree-of-wisdom');
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INSUFFICIENT_ESSENCE');
+    });
+
+    it('should reject when totem has insufficient happiness', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        stage: 4,
+        species: 'fox',
+        happiness: 2, // need 5 for Decree of Wisdom
+        sanctum: { seated: true, seatIndex: 0, onMission: false },
+      });
+      dbClient.getItem.mockResolvedValue(null);
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+
+      const result = await sanctumService.startCouncilMission(testUserId, testTotemId, 'cm_decree-of-wisdom');
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('INSUFFICIENT_HAPPINESS');
+    });
+  });
+
+  // ===========================================================================
+  // startCouncilMission - success
+  // ===========================================================================
+
+  describe('startCouncilMission - success', () => {
+    it('should create mission record and deduct costs', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        stage: 4,
+        species: 'fox',
+        happiness: 50,
+        sanctum: { seated: true, seatIndex: 0, onMission: false },
+      });
+      dbClient.getItem.mockResolvedValue(null); // no active mission
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+      dbClient.deductEssence.mockResolvedValue({ success: true, newBalance: 985 });
+      dbClient.updateTotem.mockResolvedValue({});
+      dbClient.putItem.mockResolvedValue({});
+
+      const result = await sanctumService.startCouncilMission(
+        testUserId,
+        testTotemId,
+        'cm_decree-of-wisdom',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.mission.missionType).toBe('cm_decree-of-wisdom');
+      expect(result.data.mission.name).toBe('Decree of Wisdom');
+      expect(result.data.newEssenceBalance).toBe(985);
+
+      // Verify Essence deduction
+      expect(dbClient.deductEssence).toHaveBeenCalledWith(
+        testUserId,
+        10,
+        { type: 'council_mission', ref: 'cm_decree-of-wisdom' },
+      );
+
+      // Verify happiness deduction (50 - 5 = 45)
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        { 'stats.happiness': 45 },
+      );
+
+      // Verify mission record creation
+      expect(dbClient.putItem).toHaveBeenCalledWith(
+        'TotemBound-ExpeditionState',
+        expect.objectContaining({
+          pk: `SANCTUM#${testUserId}`,
+          sk: `MISSION#ACTIVE#${testTotemId}`,
+          totemId: testTotemId,
+          missionType: 'cm_decree-of-wisdom',
+          status: 'in_progress',
+          claimed: false,
+        }),
+      );
+    });
+
+    it('should set missionEndsAt on totem when starting mission', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        stage: 4,
+        species: 'fox',
+        happiness: 50,
+        sanctum: { seated: true, seatIndex: 0, onMission: false },
+      });
+      dbClient.getItem.mockResolvedValue(null);
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+      dbClient.deductEssence.mockResolvedValue({ success: true, newBalance: 990 });
+      dbClient.updateTotem.mockResolvedValue({});
+      dbClient.putItem.mockResolvedValue({});
+
+      const result = await sanctumService.startCouncilMission(
+        testUserId,
+        testTotemId,
+        'cm_decree-of-wisdom',
+      );
+
+      expect(result.success).toBe(true);
+
+      // Verify updateTotem was called with sanctum containing missionEndsAt
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        {
+          sanctum: expect.objectContaining({
+            onMission: true,
+            missionEndsAt: expect.any(String),
+          }),
+        },
+      );
+    });
+
+    it('should set endsAt based on mission duration', async () => {
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        stage: 4,
+        species: 'fox',
+        happiness: 50,
+        sanctum: { seated: true, seatIndex: 0, onMission: false },
+      });
+      dbClient.getItem.mockResolvedValue(null);
+      dbClient.getUser.mockResolvedValue({ currencies: { essence: 1000 } });
+      dbClient.deductEssence.mockResolvedValue({ success: true, newBalance: 955 });
+      dbClient.updateTotem.mockResolvedValue({});
+      dbClient.putItem.mockResolvedValue({});
+
+      const result = await sanctumService.startCouncilMission(
+        testUserId,
+        testTotemId,
+        'cm_peace-summit',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.mission.duration).toBe(21600); // 6 hours
+
+      // Verify endsAt is ~6 hours from now
+      const startedAt = new Date(result.data.mission.startedAt).getTime();
+      const endsAt = new Date(result.data.mission.endsAt).getTime();
+      expect(endsAt - startedAt).toBe(21600 * 1000);
+    });
+  });
+
+  // ===========================================================================
+  // claimCouncilMission
+  // ===========================================================================
+
+  describe('claimCouncilMission', () => {
+    it('should reject when no active mission exists', async () => {
+      dbClient.getItem.mockResolvedValue(null);
+
+      const result = await sanctumService.claimCouncilMission(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSION_NOT_FOUND');
+    });
+
+    it('should reject when mission is not yet complete', async () => {
+      const futureEndsAt = new Date(Date.now() + 3600000).toISOString(); // 1 hour from now
+      dbClient.getItem.mockResolvedValue({
+        pk: `SANCTUM#${testUserId}`,
+        sk: `MISSION#ACTIVE#${testTotemId}`,
+        totemId: testTotemId,
+        missionType: 'cm_decree-of-wisdom',
+        endsAt: futureEndsAt,
+        status: 'in_progress',
+      });
+
+      const result = await sanctumService.claimCouncilMission(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSION_NOT_COMPLETE');
+    });
+
+    it('should award XP and rune drops when mission is complete', async () => {
+      const pastEndsAt = new Date(Date.now() - 1000).toISOString(); // ended 1 second ago
+      dbClient.getItem.mockResolvedValue({
+        pk: `SANCTUM#${testUserId}`,
+        sk: `MISSION#ACTIVE#${testTotemId}`,
+        totemId: testTotemId,
+        missionType: 'cm_decree-of-wisdom',
+        endsAt: pastEndsAt,
+        status: 'in_progress',
+      });
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        sanctum: { seated: true, seatIndex: 0, onMission: true },
+      });
+      dbClient.updateTotem.mockResolvedValue({});
+      dbClient.addRunes.mockResolvedValue({ lesser: 1, greater: 0, ancient: 0 });
+      dbClient.deleteItem.mockResolvedValue({});
+
+      const result = await sanctumService.claimCouncilMission(testUserId, testTotemId);
+
+      expect(result.success).toBe(true);
+      expect(result.data.rewards.xp).toBe(20); // Decree of Wisdom XP
+      expect(result.data.rewards.runesEarned).toBeDefined();
+
+      // Verify XP was added to totem (8000 + 20)
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        { experience: 8020 },
+      );
+
+      // Verify mission record was deleted
+      expect(dbClient.deleteItem).toHaveBeenCalledWith(
+        'TotemBound-ExpeditionState',
+        {
+          pk: `SANCTUM#${testUserId}`,
+          sk: `MISSION#ACTIVE#${testTotemId}`,
+        },
+      );
+
+      // Verify onMission flag cleared
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        { sanctum: expect.objectContaining({ onMission: false }) },
+      );
+    });
+
+    it('should clear onMission and missionEndsAt on totem when claiming', async () => {
+      const pastEndsAt = new Date(Date.now() - 5000).toISOString();
+      dbClient.getItem.mockResolvedValue({
+        pk: `SANCTUM#${testUserId}`,
+        sk: `MISSION#ACTIVE#${testTotemId}`,
+        totemId: testTotemId,
+        missionType: 'cm_territorial-survey',
+        endsAt: pastEndsAt,
+        status: 'in_progress',
+      });
+      dbClient.getTotem.mockResolvedValue({
+        experience: 9000,
+        species: 'wolf',
+        sanctum: { seated: true, seatIndex: 1, onMission: true, missionEndsAt: pastEndsAt },
+      });
+      dbClient.updateTotem.mockResolvedValue({});
+      dbClient.addRunes.mockResolvedValue({ lesser: 0, greater: 0, ancient: 0 });
+      dbClient.deleteItem.mockResolvedValue({});
+
+      const result = await sanctumService.claimCouncilMission(testUserId, testTotemId);
+      expect(result.success).toBe(true);
+
+      // Verify updateTotem clears both onMission and missionEndsAt
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        {
+          sanctum: expect.objectContaining({
+            onMission: false,
+            missionEndsAt: null,
+          }),
+        },
+      );
+    });
+  });
+
+  // ===========================================================================
+  // cancelCouncilMission
+  // ===========================================================================
+
+  describe('cancelCouncilMission', () => {
+    it('should reject when no active mission exists', async () => {
+      dbClient.getItem.mockResolvedValue(null);
+
+      const result = await sanctumService.cancelCouncilMission(testUserId, testTotemId);
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('MISSION_NOT_FOUND');
+    });
+
+    it('should cancel successfully without giving rewards', async () => {
+      dbClient.getItem.mockResolvedValue({
+        pk: `SANCTUM#${testUserId}`,
+        sk: `MISSION#ACTIVE#${testTotemId}`,
+        totemId: testTotemId,
+        missionType: 'cm_peace-summit',
+        status: 'in_progress',
+      });
+      dbClient.deleteItem.mockResolvedValue({});
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        sanctum: { seated: true, seatIndex: 0, onMission: true },
+      });
+      dbClient.updateTotem.mockResolvedValue({});
+
+      const result = await sanctumService.cancelCouncilMission(testUserId, testTotemId);
+
+      expect(result.success).toBe(true);
+      expect(result.data.cancelled).toBe(true);
+      expect(result.data.missionType).toBe('cm_peace-summit');
+
+      // Verify no Essence was added
+      expect(dbClient.addEssence).not.toHaveBeenCalled();
+
+      // Verify mission record was deleted
+      expect(dbClient.deleteItem).toHaveBeenCalledWith(
+        'TotemBound-ExpeditionState',
+        {
+          pk: `SANCTUM#${testUserId}`,
+          sk: `MISSION#ACTIVE#${testTotemId}`,
+        },
+      );
+
+      // Verify onMission flag cleared
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        { sanctum: expect.objectContaining({ onMission: false }) },
+      );
+    });
+
+    it('should clear onMission and missionEndsAt on totem when cancelling', async () => {
+      dbClient.getItem.mockResolvedValue({
+        pk: `SANCTUM#${testUserId}`,
+        sk: `MISSION#ACTIVE#${testTotemId}`,
+        totemId: testTotemId,
+        missionType: 'cm_territorial-survey',
+        status: 'in_progress',
+      });
+      dbClient.deleteItem.mockResolvedValue({});
+      dbClient.getTotem.mockResolvedValue({
+        experience: 8000,
+        species: 'fox',
+        sanctum: { seated: true, seatIndex: 0, onMission: true, missionEndsAt: '2026-03-29T00:00:00Z' },
+      });
+      dbClient.updateTotem.mockResolvedValue({});
+
+      const result = await sanctumService.cancelCouncilMission(testUserId, testTotemId);
+      expect(result.success).toBe(true);
+
+      // Verify updateTotem clears both onMission and missionEndsAt
+      expect(dbClient.updateTotem).toHaveBeenCalledWith(
+        testUserId,
+        testTotemId,
+        {
+          sanctum: expect.objectContaining({
+            onMission: false,
+            missionEndsAt: null,
+          }),
+        },
+      );
+    });
+  });
+
+  // ===========================================================================
+  // getCouncilMissions
+  // ===========================================================================
+
+  describe('getCouncilMissions', () => {
+    it('should return missions grouped by tier', () => {
+      const grouped = sanctumService.getCouncilMissions();
+      expect(grouped.governance).toHaveLength(3);
+      expect(grouped.diplomacy).toHaveLength(3);
+      expect(grouped.legacy).toHaveLength(3);
+    });
+
+    it('should include correct mission IDs per tier', () => {
+      const grouped = sanctumService.getCouncilMissions();
+      const govIds = grouped.governance.map(m => m.id);
+      expect(govIds).toContain('cm_decree-of-wisdom');
+      expect(govIds).toContain('cm_territorial-survey');
+      expect(govIds).toContain('cm_spirit-audience');
+
+      const dipIds = grouped.diplomacy.map(m => m.id);
+      expect(dipIds).toContain('cm_peace-summit');
+      expect(dipIds).toContain('cm_alliance-forging');
+      expect(dipIds).toContain('cm_elder-exchange');
+
+      const legIds = grouped.legacy.map(m => m.id);
+      expect(legIds).toContain('cm_rite-of-passage');
+      expect(legIds).toContain('cm_ancient-convocation');
+      expect(legIds).toContain('cm_founding-ritual');
+    });
+  });
+
+  // ===========================================================================
+  // COUNCIL_MISSIONS constant
+  // ===========================================================================
+
+  describe('COUNCIL_MISSIONS constant', () => {
+    it('should have 9 missions defined', () => {
+      expect(Object.keys(sanctumService.COUNCIL_MISSIONS)).toHaveLength(9);
+    });
+
+    it('should have increasing costs by tier', () => {
+      const missions = sanctumService.COUNCIL_MISSIONS;
+      // Governance < Diplomacy < Legacy
+      expect(missions['cm_decree-of-wisdom'].cost.essence).toBeLessThan(
+        missions['cm_peace-summit'].cost.essence,
+      );
+      expect(missions['cm_peace-summit'].cost.essence).toBeLessThan(
+        missions['cm_rite-of-passage'].cost.essence,
+      );
+    });
+  });
+});

--- a/test/totem-handlers.test.js
+++ b/test/totem-handlers.test.js
@@ -340,9 +340,5 @@ describe('Totem Handlers', () => {
       expect(result.attributes.nickname).toBeNull();
     });
 
-    it('should set isStaked to false (Web2)', () => {
-      const result = transformTotemForApi(makeDbTotem());
-      expect(result.attributes.isStaked).toBe(false);
-    });
   });
 });


### PR DESCRIPTION
add Elder Sanctum API and rune transaction logging
  - Sanctum endpoints: seat, unseat, council missions, claim, passive earnings
  - Rune drops now logged in Transactions table
  - Totem availability utils for sanctum/mission state checks
  - Swagger docs updated for all new endpoints